### PR TITLE
Fix doc error for API gateway lambda authoriser example

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ exports.handler = async (event) => {
   let payload;
   try {
     // If the token is not valid, an error is thrown:
-    payload = await jwtVerifier.verify(jwt);
+    payload = await jwtVerifier.verify(accessToken);
   } catch {
     // API Gateway wants this *exact* error message, otherwise it returns 500 instead of 401:
     throw new Error("Unauthorized");
@@ -639,7 +639,7 @@ exports.handler = async (event) => {
   let payload;
   try {
     // If the token is not valid, an error is thrown:
-    payload = await jwtVerifier.verify(jwt);
+    payload = await jwtVerifier.verify(accessToken);
   } catch {
     // API Gateway wants this *exact* error message, otherwise it returns 500 instead of 401:
     throw new Error("Unauthorized");


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/awslabs/aws-jwt-verify/issues/7 

*Description of changes:* Fixes document error for AWS API gateway lambda authoriser examples


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
