### PR TITLE
Simplified typings, for better readability and to enable proper tsdoc hints on create calls

### DIFF
--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -109,6 +109,19 @@ type CognitoJwtVerifierMultiUserPool<
 >;
 
 /**
+ * Parameters used for verification of a JWT.
+ * The first parameter is the JWT, which is (of course) mandatory.
+ * The second parameter is an object with specific properties to use during verification.
+ * The second parameter is only mandatory if its mandatory members (e.g. client_id) were not
+ *  yet provided at verifier level. In that case, they must now be provided.
+ */
+type CognitoVerifyParameters<SpecificVerifyProperties> = {
+  [key: string]: never;
+} extends SpecificVerifyProperties
+  ? [jwt: string, props?: SpecificVerifyProperties]
+  : [jwt: string, props: SpecificVerifyProperties];
+
+/**
  * Validate claims of a decoded Cognito JWT.
  * This function throws an error in case there's any validation issue.
  *
@@ -276,9 +289,7 @@ export class CognitoJwtVerifier<
    * @returns The payload of the JWT––if the JWT is valid, otherwise an error is thrown
    */
   public verifySync<T extends SpecificVerifyProperties>(
-    ...args: { [key: string]: never } extends SpecificVerifyProperties
-      ? [jwt: string, props?: T & SpecificVerifyProperties]
-      : [jwt: string, props: T & SpecificVerifyProperties]
+    ...args: CognitoVerifyParameters<SpecificVerifyProperties>
   ): CognitoIdOrAccessTokenPayload<IssuerConfig, T> {
     const payload = super.verifySync(...args);
     const issuerConfig = this.getIssuerConfig(payload.iss);
@@ -300,9 +311,7 @@ export class CognitoJwtVerifier<
    * @returns Promise that resolves to the payload of the JWT––if the JWT is valid, otherwise the promise rejects
    */
   public async verify<T extends SpecificVerifyProperties>(
-    ...args: { [key: string]: never } extends SpecificVerifyProperties
-      ? [jwt: string, props?: T & SpecificVerifyProperties]
-      : [jwt: string, props: T & SpecificVerifyProperties]
+    ...args: CognitoVerifyParameters<SpecificVerifyProperties>
   ): Promise<CognitoIdOrAccessTokenPayload<IssuerConfig, T>> {
     const payload = await super.verify(...args);
     const issuerConfig = this.getIssuerConfig(payload.iss);

--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -14,10 +14,7 @@ import {
   assertStringEquals,
   assertStringArraysOverlap,
 } from "./assert.js";
-import {
-  StillToProvideVerifyProps,
-  WithoutOptionalFields,
-} from "./typing-util.js";
+import { Properties } from "./typing-util.js";
 
 interface CognitoVerifyProperties {
   /**
@@ -67,21 +64,49 @@ interface CognitoVerifyProperties {
   }) => Promise<void> | void;
 }
 
-/** Interface for Cognito JWT verifier properties, for a single User Pool */
-interface CognitoJwtVerifierProperties
-  extends Partial<CognitoVerifyProperties> {
+/** Type for Cognito JWT verifier properties, for a single User Pool */
+type CognitoJwtVerifierProperties = {
   /** The User Pool whose JWTs you want to verify */
   userPoolId: string;
-}
+} & Partial<CognitoVerifyProperties>;
 
 /**
- * Interface for Cognito JWT verifier properties, when multiple User Pools are used in the verifier.
+ * Type for Cognito JWT verifier properties, when multiple User Pools are used in the verifier.
  * In this case, you should be explicit in mapping `clientId` to User Pool.
  */
-interface CognitoJwtVerifierMultiProperties extends CognitoVerifyProperties {
+type CognitoJwtVerifierMultiProperties = {
   /** The User Pool whose JWTs you want to verify */
   userPoolId: string;
-}
+} & CognitoVerifyProperties;
+
+/**
+ * Cognito JWT Verifier for a single user pool
+ */
+type CognitoJwtVerifierSingleUserPool<T extends CognitoJwtVerifierProperties> =
+  CognitoJwtVerifier<
+    Properties<CognitoVerifyProperties, T>,
+    T &
+      JwtRsaVerifierProperties<CognitoVerifyProperties> & {
+        userPoolId: string;
+        audience: null;
+      },
+    false
+  >;
+
+/**
+ * Cognito JWT Verifier for multiple user pools
+ */
+type CognitoJwtVerifierMultiUserPool<
+  T extends CognitoJwtVerifierMultiProperties
+> = CognitoJwtVerifier<
+  Properties<CognitoVerifyProperties, T>,
+  T &
+    JwtRsaVerifierProperties<CognitoVerifyProperties> & {
+      userPoolId: string;
+      audience: null;
+    },
+  true
+>;
 
 /**
  * Validate claims of a decoded Cognito JWT.
@@ -152,12 +177,14 @@ function validateCognitoJwtFields(
  * Class representing a verifier for JWTs signed by Amazon Cognito
  */
 export class CognitoJwtVerifier<
-  StillToProvide extends Partial<CognitoVerifyProperties>,
-  IssuerConfig extends JwtRsaVerifierProperties & CognitoJwtVerifierProperties,
+  SpecificVerifyProperties extends Partial<CognitoVerifyProperties>,
+  IssuerConfig extends JwtRsaVerifierProperties<SpecificVerifyProperties> & {
+    userPoolId: string;
+    audience: null;
+  },
   MultiIssuer extends boolean
 > extends JwtRsaVerifierBase<
-  StillToProvide,
-  CognitoVerifyProperties,
+  SpecificVerifyProperties,
   IssuerConfig,
   MultiIssuer
 > {
@@ -214,17 +241,9 @@ export class CognitoJwtVerifier<
    * @returns An Cognito JWT Verifier instance, that you can use to verify Cognito signed JWTs with
    */
   static create<T extends CognitoJwtVerifierProperties>(
-    props: T,
+    verifyProperties: T & Partial<CognitoJwtVerifierProperties>,
     additionalProperties?: { jwksCache: JwksCache }
-  ): CognitoJwtVerifier<
-    StillToProvideVerifyProps<
-      WithoutOptionalFields<CognitoVerifyProperties>,
-      typeof props
-    > &
-      Partial<CognitoVerifyProperties>,
-    T & JwtRsaVerifierProperties,
-    false
-  >;
+  ): CognitoJwtVerifierSingleUserPool<T>;
 
   /**
    * Create a Cognito JWT verifier for multiple User Pools
@@ -235,20 +254,18 @@ export class CognitoJwtVerifier<
    * @returns An Cognito JWT Verifier instance, that you can use to verify Cognito signed JWTs with
    */
   static create<T extends CognitoJwtVerifierMultiProperties>(
-    props: T[],
+    props: (T & Partial<CognitoJwtVerifierMultiProperties>)[],
     additionalProperties?: { jwksCache: JwksCache }
-  ): CognitoJwtVerifier<
-    Partial<CognitoVerifyProperties>,
-    T & JwtRsaVerifierProperties,
-    true
-  >;
+  ): CognitoJwtVerifierMultiUserPool<T>;
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   static create(
-    props: CognitoJwtVerifierProperties | CognitoJwtVerifierMultiProperties[],
+    verifyProperties:
+      | CognitoJwtVerifierProperties
+      | CognitoJwtVerifierMultiProperties[],
     additionalProperties?: { jwksCache: JwksCache }
   ) {
-    return new this(props, additionalProperties?.jwksCache);
+    return new this(verifyProperties, additionalProperties?.jwksCache);
   }
 
   /**
@@ -258,19 +275,11 @@ export class CognitoJwtVerifier<
    * @param props Verification properties
    * @returns The payload of the JWT––if the JWT is valid, otherwise an error is thrown
    */
-  public verifySync<
-    OptionalProps extends Partial<CognitoVerifyProperties>,
-    MandatoryProps extends StillToProvide
-  >(
-    ...args: { [key: string]: never } extends StillToProvide
-      ? [jwt: string, props?: OptionalProps]
-      : [jwt: string, props: MandatoryProps]
-  ): CognitoIdOrAccessTokenPayload<
-    IssuerConfig,
-    { [key: string]: never } extends StillToProvide
-      ? OptionalProps
-      : MandatoryProps
-  > {
+  public verifySync<T extends SpecificVerifyProperties>(
+    ...args: { [key: string]: never } extends SpecificVerifyProperties
+      ? [jwt: string, props?: T & SpecificVerifyProperties]
+      : [jwt: string, props: T & SpecificVerifyProperties]
+  ): CognitoIdOrAccessTokenPayload<IssuerConfig, T> {
     const payload = super.verifySync(...args);
     const issuerConfig = this.getIssuerConfig(payload.iss);
     const verifyProperties = {
@@ -278,12 +287,7 @@ export class CognitoJwtVerifier<
       ...args[1],
     };
     validateCognitoJwtFields(payload, verifyProperties);
-    return payload as CognitoIdOrAccessTokenPayload<
-      IssuerConfig,
-      { [key: string]: never } extends StillToProvide
-        ? OptionalProps
-        : MandatoryProps
-    >;
+    return payload as CognitoIdOrAccessTokenPayload<IssuerConfig, T>;
   }
 
   /**
@@ -295,21 +299,11 @@ export class CognitoJwtVerifier<
    * @param props Verification properties
    * @returns Promise that resolves to the payload of the JWT––if the JWT is valid, otherwise the promise rejects
    */
-  public async verify<
-    OptionalProps extends Partial<CognitoVerifyProperties>,
-    MandatoryProps extends StillToProvide
-  >(
-    ...args: { [key: string]: never } extends StillToProvide
-      ? [jwt: string, props?: OptionalProps]
-      : [jwt: string, props: MandatoryProps]
-  ): Promise<
-    CognitoIdOrAccessTokenPayload<
-      IssuerConfig,
-      { [key: string]: never } extends StillToProvide
-        ? OptionalProps
-        : MandatoryProps
-    >
-  > {
+  public async verify<T extends SpecificVerifyProperties>(
+    ...args: { [key: string]: never } extends SpecificVerifyProperties
+      ? [jwt: string, props?: T & SpecificVerifyProperties]
+      : [jwt: string, props: T & SpecificVerifyProperties]
+  ): Promise<CognitoIdOrAccessTokenPayload<IssuerConfig, T>> {
     const payload = await super.verify(...args);
     const issuerConfig = this.getIssuerConfig(payload.iss);
     const verifyProperties = {
@@ -317,12 +311,7 @@ export class CognitoJwtVerifier<
       ...args[1],
     };
     validateCognitoJwtFields(payload, verifyProperties);
-    return payload as CognitoIdOrAccessTokenPayload<
-      IssuerConfig,
-      { [key: string]: never } extends StillToProvide
-        ? OptionalProps
-        : MandatoryProps
-    >;
+    return payload as CognitoIdOrAccessTokenPayload<IssuerConfig, T>;
   }
 
   /**

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -110,6 +110,19 @@ type JwtRsaVerifierSingleIssuer<
 >;
 
 /**
+ * Parameters used for verification of a JWT.
+ * The first parameter is the JWT, which is (of course) mandatory.
+ * The second parameter is an object with specific properties to use during verification.
+ * The second parameter is only mandatory if its mandatory members (e.g. audience) were not
+ *  yet provided at verifier level. In that case, they must now be provided.
+ */
+type VerifyParameters<SpecificVerifyProperties> = {
+  [key: string]: never;
+} extends SpecificVerifyProperties
+  ? [jwt: string, props?: SpecificVerifyProperties]
+  : [jwt: string, props: SpecificVerifyProperties];
+
+/**
  * JWT Verifier (RSA) for multiple issuers
  */
 type JwtRsaVerifierMultiIssuer<
@@ -480,9 +493,7 @@ export abstract class JwtRsaVerifierBase<
    * @returns The payload of the JWT––if the JWT is valid, otherwise an error is thrown
    */
   public verifySync(
-    ...args: { [key: string]: never } extends SpecificVerifyProperties
-      ? [jwt: string, props?: Partial<SpecificVerifyProperties>]
-      : [jwt: string, props: SpecificVerifyProperties]
+    ...args: VerifyParameters<SpecificVerifyProperties>
   ): JwtPayload {
     const { decomposedJwt, jwksUri, verifyProperties } =
       this.getVerifyParameters(args[0], args[1]);
@@ -504,9 +515,7 @@ export abstract class JwtRsaVerifierBase<
    * @returns Promise that resolves to the payload of the JWT––if the JWT is valid, otherwise the promise rejects
    */
   public async verify(
-    ...args: { [key: string]: never } extends SpecificVerifyProperties
-      ? [jwt: string, props?: Partial<SpecificVerifyProperties>]
-      : [jwt: string, props: SpecificVerifyProperties]
+    ...args: VerifyParameters<SpecificVerifyProperties>
   ): Promise<JwtPayload> {
     const { decomposedJwt, jwksUri, verifyProperties } =
       this.getVerifyParameters(args[0], args[1]);

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -19,10 +19,7 @@ import {
   assertStringEquals,
 } from "./assert.js";
 import { JwtHeader, JwtPayload } from "./jwt-model.js";
-import {
-  StillToProvideVerifyProps,
-  WithoutOptionalFields,
-} from "./typing-util.js";
+import { Properties } from "./typing-util.js";
 import { decomposeJwt, validateJwtFields } from "./jwt.js";
 import {
   JwtInvalidSignatureError,
@@ -68,8 +65,8 @@ interface VerifyProperties {
   }) => Promise<void> | void;
 }
 
-/** Interface for JWT RSA verifier properties, for a single issuer */
-export interface JwtRsaVerifierProperties extends Partial<VerifyProperties> {
+/** Type for JWT RSA verifier properties, for a single issuer */
+export type JwtRsaVerifierProperties<VerifyProps> = {
   /**
    * URI where the JWKS (JSON Web Key Set) can be downloaded from.
    * The JWKS contains one or more JWKs, which represent the public keys with which
@@ -81,13 +78,13 @@ export interface JwtRsaVerifierProperties extends Partial<VerifyProperties> {
    * Set this to the expected value of the `iss` claim in the JWT.
    */
   issuer: string;
-}
+} & Partial<VerifyProps>;
 
 /**
- * Interface for JWT RSA verifier properties, when multiple issuers are used in the verifier.
+ * Type for JWT RSA verifier properties, when multiple issuers are used in the verifier.
  * In this case, you should be explicit in mapping audience to issuer.
  */
-interface JwtRsaVerifierMultiProperties extends VerifyProperties {
+type JwtRsaVerifierMultiProperties<T> = {
   /**
    * URI where the JWKS (JSON Web Key Set) can be downloaded from.
    * The JWKS contains one or more JWKs, which represent the public keys with which
@@ -99,7 +96,29 @@ interface JwtRsaVerifierMultiProperties extends VerifyProperties {
    * Set this to the expected value of the `iss` claim in the JWT.
    */
   issuer: string;
-}
+} & T;
+
+/**
+ * JWT Verifier (RSA) for a single issuer
+ */
+type JwtRsaVerifierSingleIssuer<
+  T extends JwtRsaVerifierProperties<VerifyProperties>
+> = JwtRsaVerifier<
+  Properties<VerifyProperties, T>,
+  T & JwtRsaVerifierProperties<VerifyProperties>,
+  false
+>;
+
+/**
+ * JWT Verifier (RSA) for multiple issuers
+ */
+type JwtRsaVerifierMultiIssuer<
+  T extends JwtRsaVerifierMultiProperties<VerifyProperties>
+> = JwtRsaVerifier<
+  Properties<VerifyProperties, T>,
+  T & JwtRsaVerifierProperties<VerifyProperties>,
+  true
+>;
 
 /**
  * Verify a JWTs signature agains a JWK. This function throws an error if the JWT is not valid
@@ -360,12 +379,8 @@ type Kid = string;
  * @param MultiIssuer Verify multiple issuers (true) or just a single one (false)
  */
 export abstract class JwtRsaVerifierBase<
-  StillToProvide extends Partial<SpecificVerifyProperties>,
   SpecificVerifyProperties,
-  IssuerConfig extends {
-    issuer: string;
-    jwksUri?: string;
-  } & Partial<SpecificVerifyProperties>,
+  IssuerConfig extends JwtRsaVerifierProperties<SpecificVerifyProperties>,
   MultiIssuer extends boolean
 > {
   private issuersConfig: Map<Issuer, IssuerConfig & { jwksUri: string }> =
@@ -460,9 +475,9 @@ export abstract class JwtRsaVerifierBase<
    * @returns The payload of the JWT––if the JWT is valid, otherwise an error is thrown
    */
   public verifySync(
-    ...args: { [key: string]: never } extends StillToProvide
+    ...args: { [key: string]: never } extends SpecificVerifyProperties
       ? [jwt: string, props?: Partial<SpecificVerifyProperties>]
-      : [jwt: string, props: StillToProvide]
+      : [jwt: string, props: SpecificVerifyProperties]
   ): JwtPayload {
     const { decomposedJwt, jwksUri, verifyProperties } =
       this.getVerifyParameters(args[0], args[1]);
@@ -484,9 +499,9 @@ export abstract class JwtRsaVerifierBase<
    * @returns Promise that resolves to the payload of the JWT––if the JWT is valid, otherwise the promise rejects
    */
   public async verify(
-    ...args: { [key: string]: never } extends StillToProvide
+    ...args: { [key: string]: never } extends SpecificVerifyProperties
       ? [jwt: string, props?: Partial<SpecificVerifyProperties>]
-      : [jwt: string, props: StillToProvide]
+      : [jwt: string, props: SpecificVerifyProperties]
   ): Promise<JwtPayload> {
     const { decomposedJwt, jwksUri, verifyProperties } =
       this.getVerifyParameters(args[0], args[1]);
@@ -562,12 +577,11 @@ export abstract class JwtRsaVerifierBase<
  * Class representing a verifier for JWTs signed with RSA (e.g. RS256)
  */
 export class JwtRsaVerifier<
-  StillToProvide extends Partial<VerifyProperties>,
-  IssuerConfig extends JwtRsaVerifierProperties,
+  SpecificVerifyProperties extends Partial<VerifyProperties>,
+  IssuerConfig extends JwtRsaVerifierProperties<SpecificVerifyProperties>,
   MultiIssuer extends boolean
 > extends JwtRsaVerifierBase<
-  StillToProvide,
-  VerifyProperties,
+  SpecificVerifyProperties,
   IssuerConfig,
   MultiIssuer
 > {
@@ -579,19 +593,11 @@ export class JwtRsaVerifier<
    * @param additionalProperties.jwksCache Overriding JWKS cache that you want to use
    * @returns An RSA JWT Verifier instance, that you can use to verify JWTs with
    */
-  static create<T extends JwtRsaVerifierProperties>(
-    verifyProperties: T,
+  static create<T extends JwtRsaVerifierProperties<VerifyProperties>>(
+    verifyProperties: T & Partial<JwtRsaVerifierProperties<VerifyProperties>>,
     additionalProperties?: { jwksCache: JwksCache }
-  ): JwtRsaVerifierBase<
-    StillToProvideVerifyProps<
-      WithoutOptionalFields<VerifyProperties>,
-      typeof verifyProperties
-    > &
-      Partial<VerifyProperties>,
-    VerifyProperties,
-    JwtRsaVerifierProperties,
-    false
-  >;
+  ): JwtRsaVerifierSingleIssuer<T>;
+
   /**
    * Create an RSA JWT verifier for multiple issuer
    *
@@ -600,20 +606,17 @@ export class JwtRsaVerifier<
    * @param additionalProperties.jwksCache Overriding JWKS cache that you want to use
    * @returns An RSA JWT Verifier instance, that you can use to verify JWTs with
    */
-  static create<T extends JwtRsaVerifierMultiProperties>(
-    verifyProperties: T[],
+  static create<T extends JwtRsaVerifierMultiProperties<VerifyProperties>>(
+    verifyProperties: (T &
+      Partial<JwtRsaVerifierProperties<VerifyProperties>>)[],
     additionalProperties?: { jwksCache: JwksCache }
-  ): JwtRsaVerifierBase<
-    Partial<VerifyProperties>,
-    VerifyProperties,
-    JwtRsaVerifierMultiProperties,
-    true
-  >;
+  ): JwtRsaVerifierMultiIssuer<T>;
+
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   static create(
     verifyProperties:
-      | JwtRsaVerifierProperties
-      | JwtRsaVerifierMultiProperties[],
+      | JwtRsaVerifierProperties<VerifyProperties>
+      | JwtRsaVerifierMultiProperties<VerifyProperties>[],
     additionalProperties?: { jwksCache: JwksCache }
   ) {
     return new this(verifyProperties, additionalProperties?.jwksCache);

--- a/src/typing-util.ts
+++ b/src/typing-util.ts
@@ -9,7 +9,7 @@
  * @param Base The base object
  * @param Provided The object whose fields should be omitted from the field list of base
  */
-export type StillToProvideVerifyKeys<Base, Provided> = keyof Omit<
+type StillToProvideVerifyKeys<Base, Provided> = keyof Omit<
   Base,
   keyof Provided
 >;
@@ -20,8 +20,11 @@ export type StillToProvideVerifyKeys<Base, Provided> = keyof Omit<
  * @param Base The base object
  * @param Provided The object whose fields should be omitted from base
  */
-export type StillToProvideVerifyProps<Base, Provided> = {
-  [key in StillToProvideVerifyKeys<Base, Provided>]: Base[key];
+type StillToProvideProperties<Base, Provided> = {
+  [key in StillToProvideVerifyKeys<
+    WithoutOptionalFields<Base>,
+    WithoutOptionalFields<Provided>
+  >]: Base[key];
 };
 
 /**
@@ -29,7 +32,7 @@ export type StillToProvideVerifyProps<Base, Provided> = {
  *
  * @param T The type to extract optional fields from
  */
-export type ExtractOptionalFields<T> = {
+type ExtractOptionalFields<T> = {
   [P in keyof T]-?: undefined extends T[P] ? P : never;
 }[keyof T];
 
@@ -38,4 +41,15 @@ export type ExtractOptionalFields<T> = {
  *
  * @param T The type to return without optional fields
  */
-export type WithoutOptionalFields<T> = Omit<T, ExtractOptionalFields<T>>;
+type WithoutOptionalFields<T> = Omit<T, ExtractOptionalFields<T>>;
+
+/**
+ * Type that returns merged properties as follows:
+ * - Properties in Base that are not in Provided, are mandatory
+ * - Properties in Base that are in Provided, are optional
+ */
+export type Properties<Base, Provided> = StillToProvideProperties<
+  Base,
+  Provided
+> &
+  Partial<Base>;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Simplified typings, for better readability and to enable proper tsdoc hints on create calls.

*Impact: This change will have no impact on regular usage of this library (e.g. all usage as explained in README). But, this might be a BREAKING change for TypeScript users, who were explicitly depending on the previous typings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
