### PR TITLE
Update jwk validation logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "aws-jwt-verify",
       "version": "1.0.1",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@tsconfig/node14": "^1.0.1",
         "@types/jest": "^27.0.2",
@@ -15,7 +16,7 @@
         "eslint": "^7.32.0",
         "eslint-plugin-security": "^1.4.0",
         "jest": "^27.2.4",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "nock": "^13.1.3",
         "prettier": "^2.4.1",
         "ts-jest": "^27.0.5",
@@ -4298,39 +4299,18 @@
       }
     },
     "node_modules/jest-junit": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.3.0.tgz",
-      "integrity": "sha512-+NmE5ogsEjFppEl90GChrk7xgz8xzvF0f+ZT5AnhW6suJC93gvQtmQjfyjDnE0Z2nXJqEkxF0WXlvjG/J+wn/g==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.0.0.tgz",
+      "integrity": "sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==",
       "dev": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
-        "strip-ansi": "^5.2.0",
+        "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2",
         "xml": "^1.0.1"
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/jest-junit/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jest-junit/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -10317,32 +10297,15 @@
       }
     },
     "jest-junit": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.3.0.tgz",
-      "integrity": "sha512-+NmE5ogsEjFppEl90GChrk7xgz8xzvF0f+ZT5AnhW6suJC93gvQtmQjfyjDnE0Z2nXJqEkxF0WXlvjG/J+wn/g==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.0.0.tgz",
+      "integrity": "sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==",
       "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
-        "strip-ansi": "^5.2.0",
+        "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2",
         "xml": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "jest-leak-detector": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint": "^7.32.0",
     "eslint-plugin-security": "^1.4.0",
     "jest": "^27.2.4",
-    "jest-junit": "^12.3.0",
+    "jest-junit": "^13.0.0",
     "nock": "^13.1.3",
     "prettier": "^2.4.1",
     "ts-jest": "^27.0.5",

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -18,10 +18,10 @@ interface DecomposedJwt {
   payload: JwtPayload;
 }
 
-const optionalJwkFields = [
+const optionalJwkFieldslist = [
   "alg", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.4
 ] as const;
-const mandatoryJwkFields = [
+const mandatoryJwkFieldslist = [
   "e", // https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1.2
   "kid", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.5 NOTE: considered mandatory by this library
   "kty", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.1
@@ -29,24 +29,23 @@ const mandatoryJwkFields = [
   "use", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.2 NOTE: considered mandatory by this library
 ] as const;
 
-interface JwkFields {
-  alg?: "RS256" | string;
-  kid: string;
-  kty: string;
-  use: string;
-  n: string;
-  e: string;
-  [key: string]: unknown;
-}
+type optionalJwkFieldsArray = typeof optionalJwkFieldslist[number];
+type mandatoryJwkFieldsArray = typeof mandatoryJwkFieldslist[number];
 
-export type Jwk = JwkFields & JsonObject;
+type optionalJwkFields = {
+  [key in optionalJwkFieldsArray]?: string;
+};
 
+type mandatoryJwkFields = {
+  [key in mandatoryJwkFieldsArray]: string;
+};
+
+export type Jwk = optionalJwkFields & mandatoryJwkFields;
 interface JwksFields {
   keys: readonly Jwk[];
 }
 
 export type Jwks = JwksFields & JsonObject;
-
 export interface JwksCache {
   getJwk(jwksUri: string, decomposedJwt: DecomposedJwt): Promise<Jwk>;
   getCachedJwk(jwksUri: string, decomposedJwt: DecomposedJwt): Jwk;
@@ -106,14 +105,14 @@ export function assertIsJwk(jwk: Json): asserts jwk is Jwk {
     throw new JwkValidationError("JWK should be an object");
   }
 
-  for (const field of mandatoryJwkFields) {
+  for (const field of mandatoryJwkFieldslist) {
     // disable eslint rule because `field` is trusted
     // eslint-disable-next-line security/detect-object-injection
     if (typeof jwk[field] !== "string") {
       throw new JwkValidationError(`JWK ${field} should be a string`);
     }
   }
-  for (const field of optionalJwkFields) {
+  for (const field of optionalJwkFieldslist) {
     // disable eslint rule because `field` is trusted
     // eslint-disable-next-line security/detect-object-injection
     if (field in jwk && typeof jwk[field] !== "string") {

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -30,7 +30,7 @@ const mandatoryJwkFields = [
 ] as const;
 
 interface JwkFields {
-  alg: "RS256" | string;
+  alg?: "RS256" | string;
   kid: string;
   kty: string;
   use: string;

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -18,10 +18,10 @@ interface DecomposedJwt {
   payload: JwtPayload;
 }
 
-const optionalJwkFieldslist = [
+const optionalJwkFieldNames = [
   "alg", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.4
 ] as const;
-const mandatoryJwkFieldslist = [
+const mandatoryJwkFieldNames = [
   "e", // https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1.2
   "kid", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.5 NOTE: considered mandatory by this library
   "kty", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.1
@@ -29,18 +29,17 @@ const mandatoryJwkFieldslist = [
   "use", // https://datatracker.ietf.org/doc/html/rfc7517#section-4.2 NOTE: considered mandatory by this library
 ] as const;
 
-type optionalJwkFieldsArray = typeof optionalJwkFieldslist[number];
-type mandatoryJwkFieldsArray = typeof mandatoryJwkFieldslist[number];
-
-type optionalJwkFields = {
-  [key in optionalJwkFieldsArray]?: string;
+type OptionalJwkFieldNames = typeof optionalJwkFieldNames[number];
+type MandatoryJwkFieldNames = typeof mandatoryJwkFieldNames[number];
+type OptionalJwkFields = {
+  [key in OptionalJwkFieldNames]?: string;
+};
+type MandatoryJwkFields = {
+  [key in MandatoryJwkFieldNames]: string;
 };
 
-type mandatoryJwkFields = {
-  [key in mandatoryJwkFieldsArray]: string;
-};
+export type Jwk = OptionalJwkFields & MandatoryJwkFields & JsonObject;
 
-export type Jwk = optionalJwkFields & mandatoryJwkFields;
 interface JwksFields {
   keys: readonly Jwk[];
 }
@@ -105,14 +104,14 @@ export function assertIsJwk(jwk: Json): asserts jwk is Jwk {
     throw new JwkValidationError("JWK should be an object");
   }
 
-  for (const field of mandatoryJwkFieldslist) {
+  for (const field of mandatoryJwkFieldNames) {
     // disable eslint rule because `field` is trusted
     // eslint-disable-next-line security/detect-object-injection
     if (typeof jwk[field] !== "string") {
       throw new JwkValidationError(`JWK ${field} should be a string`);
     }
   }
-  for (const field of optionalJwkFieldslist) {
+  for (const field of optionalJwkFieldNames) {
     // disable eslint rule because `field` is trusted
     // eslint-disable-next-line security/detect-object-injection
     if (field in jwk && typeof jwk[field] !== "string") {

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -125,8 +125,13 @@ function verifySignatureAgainstJwk(
   // Check JWK use
   assertStringEquals("JWK use", jwk.use, "sig");
 
+  // Check JWK kty
+  assertStringEquals("JWK kty", jwk.kty, "RSA");
+
   // Check that JWT signature algorithm matches JWK
-  assertStringEquals("JWT signature algorithm", header.alg, jwk.alg);
+  if (jwk.alg) {
+    assertStringEquals("JWT signature algorithm", header.alg, jwk.alg);
+  }
 
   // Check JWT signature algorithm is RS256
   assertStringEquals("JWT signature algorithm", header.alg, "RS256");

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -133,14 +133,6 @@ function verifySignatureAgainstJwk(
     assertStringEquals("JWT signature algorithm", header.alg, jwk.alg);
   }
 
-  // Check JWT signature length matches JWT header alg
-  const signature = Buffer.from(signatureB64, "base64");
-  assertStringEquals(
-    "JWT signature length",
-    header.alg,
-    `RS${signature.length}`
-  );
-
   // Check JWT signature algorithm is RS256
   assertStringEquals("JWT signature algorithm", header.alg, "RS256");
 
@@ -151,7 +143,7 @@ function verifySignatureAgainstJwk(
   // RS256 is known in OpenSSL as RSA-SHA256
   const valid = createVerify("RSA-SHA256")
     .update(`${headerB64}.${payloadB64}`)
-    .verify(publicKey, signature);
+    .verify(publicKey, signatureB64, "base64");
   if (!valid) {
     throw new JwtInvalidSignatureError("Invalid signature");
   }

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -135,8 +135,11 @@ function verifySignatureAgainstJwk(
 
   // Check JWT signature length matches JWT header alg
   const signature = Buffer.from(signatureB64, "base64");
-
-  assertStringEquals("blah blah", header.alg, `RS${signature.length}`);
+  assertStringEquals(
+    "JWT signature length",
+    header.alg,
+    `RS${signature.length}`
+  );
 
   // Check JWT signature algorithm is RS256
   assertStringEquals("JWT signature algorithm", header.alg, "RS256");

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -133,6 +133,11 @@ function verifySignatureAgainstJwk(
     assertStringEquals("JWT signature algorithm", header.alg, jwk.alg);
   }
 
+  // Check JWT signature length matches JWT header alg
+  const signature = Buffer.from(signatureB64, "base64");
+
+  assertStringEquals("blah blah", header.alg, `RS${signature.length}`);
+
   // Check JWT signature algorithm is RS256
   assertStringEquals("JWT signature algorithm", header.alg, "RS256");
 
@@ -143,7 +148,7 @@ function verifySignatureAgainstJwk(
   // RS256 is known in OpenSSL as RSA-SHA256
   const valid = createVerify("RSA-SHA256")
     .update(`${headerB64}.${payloadB64}`)
-    .verify(publicKey, signatureB64, "base64");
+    .verify(publicKey, signature);
   if (!valid) {
     throw new JwtInvalidSignatureError("Invalid signature");
   }

--- a/tests/unit/jwk.test.ts
+++ b/tests/unit/jwk.test.ts
@@ -212,7 +212,7 @@ describe("unit tests jwk", () => {
         expect(statement).toThrow("JWK should be an object");
         expect(statement).toThrow(JwkValidationError);
       });
-      test("JWK mandatory field alg is not a string", () => {
+      test("JWK optional field alg is not a string", () => {
         const jwk = {
           kty: "RSA",
           use: "sig",

--- a/tests/unit/jwk.test.ts
+++ b/tests/unit/jwk.test.ts
@@ -212,6 +212,19 @@ describe("unit tests jwk", () => {
         expect(statement).toThrow("JWK should be an object");
         expect(statement).toThrow(JwkValidationError);
       });
+      test("JWK mandatory field alg is not a string", () => {
+        const jwk = {
+          kty: "RSA",
+          use: "sig",
+          kid: "nOo3ZDrODXEK1jKWhXslHR_KXEq",
+          n: "1",
+          e: "2",
+          alg: 123,
+        };
+        const statement = () => assertIsJwk(jwk);
+        expect(statement).toThrow("JWK alg should be a string");
+        expect(statement).toThrow(JwkValidationError);
+      });
     });
     describe("JWKS", () => {
       test("no keys", () => {

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -41,6 +41,18 @@ describe("unit tests jwt verifier", () => {
 
   describe("verifySync", () => {
     describe("basic cases", () => {
+      test("happy flow with jwk", () => {
+        const issuer = "https://example.com";
+        const audience = "1234";
+        const signedJwt = signJwt(
+          { kid: keypair.jwk.kid },
+          { aud: audience, iss: issuer, hello: "world" },
+          keypair.privateKey
+        );
+        expect(
+          verifyJwtSync(signedJwt, keypair.jwk, { issuer, audience })
+        ).toMatchObject({ hello: "world" });
+      });
       test("happy flow with jwk without alg", () => {
         const issuer = "https://example.com";
         const audience = "1234";
@@ -53,18 +65,6 @@ describe("unit tests jwt verifier", () => {
         );
         expect(
           verifyJwtSync(signedJwt, copiedjwk, { issuer, audience })
-        ).toMatchObject({ hello: "world" });
-      });
-      test("happy flow with jwk", () => {
-        const issuer = "https://example.com";
-        const audience = "1234";
-        const signedJwt = signJwt(
-          { kid: keypair.jwk.kid },
-          { aud: audience, iss: issuer, hello: "world" },
-          keypair.privateKey
-        );
-        expect(
-          verifyJwtSync(signedJwt, keypair.jwk, { issuer, audience })
         ).toMatchObject({ hello: "world" });
       });
       test("happy flow with jwks", () => {

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -41,6 +41,20 @@ describe("unit tests jwt verifier", () => {
 
   describe("verifySync", () => {
     describe("basic cases", () => {
+      test("happy flow with jwk without alg", () => {
+        const issuer = "https://example.com";
+        const audience = "1234";
+        const copiedjwk = { ...keypair.jwk };
+        delete copiedjwk.alg;
+        const signedJwt = signJwt(
+          { kid: copiedjwk.kid },
+          { aud: audience, iss: issuer, hello: "world" },
+          keypair.privateKey
+        );
+        expect(
+          verifyJwtSync(signedJwt, copiedjwk, { issuer, audience })
+        ).toMatchObject({ hello: "world" });
+      });
       test("happy flow with jwk", () => {
         const issuer = "https://example.com";
         const audience = "1234";

--- a/tests/unit/test-util.ts
+++ b/tests/unit/test-util.ts
@@ -16,7 +16,7 @@ export function allowAllRealNetworkTraffic() {
 
 export function generateKeyPair(options?: { kid?: string }) {
   const { privateKey, publicKey } = generateKeyPairSync("rsa", {
-    modulusLength: 4096,
+    modulusLength: 2048,
     publicExponent: 0x10001,
   });
   const jwk = publicKeyToJwk(publicKey, { kid: options?.kid });

--- a/tests/unit/test-util.ts
+++ b/tests/unit/test-util.ts
@@ -16,7 +16,7 @@ export function allowAllRealNetworkTraffic() {
 
 export function generateKeyPair(options?: { kid?: string }) {
   const { privateKey, publicKey } = generateKeyPairSync("rsa", {
-    modulusLength: 2048,
+    modulusLength: 4096,
     publicExponent: 0x10001,
   });
   const jwk = publicKeyToJwk(publicKey, { kid: options?.kid });


### PR DESCRIPTION
*Issue #, if available:* Fixes #6

*Description of changes:*

-  Consider alg as an optional field on the JWK while validating JWK
-  Evaluate if kty on the JWK is set to RSA
-  If JWK has alg set, then validate that alg set in JWT header matches the alg element of JWK
-  Validate that JWT alg header is set to RS256
-  Update jest version


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
