### PR TITLE
Include raw jwt in errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Supported parameters are:
 - `scope` (optional): verify that the JWT's `scope` claim matches your expectation (only of use for access tokens). Provide a string, or an array of strings to allow multiple scopes (i.e. one of these scopes must match the JWT). See also [Checking scope](#Checking-scope).
 - `graceSeconds` (optional, default `0`): to account for clock differences between systems, provide the number of seconds beyond JWT expiry (`exp` claim) or before "not before" (`nbf` claim) you will allow.
 - `customJwtCheck` (optional): your custom function with additional JWT (and JWK) checks to execute (see also below).
-- `includeRawJwtInErrors` (optional): set to true if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
+- `includeRawJwtInErrors` (optional): set to `true` if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
 
 ```typescript
 import { CognitoJwtVerifier } from "aws-jwt-verify";
@@ -354,7 +354,7 @@ Supported parameters are:
 - `scope` (optional): verify that the JWT's `scope` claim matches your expectation (only of use for access tokens). Provide a string, or an array of strings to allow multiple scopes (i.e. one of these scopes must match the JWT). See also [Checking scope](#checking-scope).
 - `graceSeconds` (optional, default `0`): to account for clock differences between systems, provide the number of seconds beyond JWT expiry (`exp` claim) or before "not before" (`nbf` claim) you will allow.
 - `customJwtCheck` (optional): your custom function with additional JWT checks to execute (see [Custom JWT and JWK checks](#custom-jwt-and-jwk-checks)).
-- `includeRawJwtInErrors` (optional): set to true if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
+- `includeRawJwtInErrors` (optional): set to `true` if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
 
 ## Verification errors
 
@@ -411,13 +411,13 @@ try {
 }
 ```
 
-The `instanceof` check in the `catch` block above is crucial, because not all errors will include the rawJwt, only errors that subclass `JwtInvalidClaimError` will. In order to understand why this makes sense, you must understand that this library verifies JWTs in 3 stages, that all must succeed for the JWT to be considered valid:
+The `instanceof` check in the `catch` block above is crucial, because not all errors will include the rawJwt, only errors that subclass `JwtInvalidClaimError` will. In order to understand why this makes sense, you should know that this library verifies JWTs in 3 stages, that all must succeed for the JWT to be considered valid:
 
 - Stage 1: Verify JWT structure and JSON parse the JWT
 - Stage 2: Verify JWT cryptographic signature (i.e. RS256)
 - Stage 3: Verify JWT claims (such as e.g. its expiration)
 
-Only in case of stage 3 verification errors, will the raw JWT be included in the error (if you set `includeRawJwtInErrors` to `true`). This way, when you look at the invalid raw JWT in the error, you'll know that its structure and signature are at least valid. You should still treat the JWT as invalid, but you might execute different business logic to handle the verification error depending on the situation at hand.
+Only in case of stage 3 verification errors, will the raw JWT be included in the error (if you set `includeRawJwtInErrors` to `true`). This way, when you look at the invalid raw JWT in the error, you'll know that its structure and signature are at least valid (stages 1 and 2 succeeded).
 
 ## The JWKS cache
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Supported parameters are:
 
 ## Verification errors
 
-When verification of a JWT fails, this library will throw an error. All errors are defined in [./src/error.ts](src/error.ts) and can be imported and tested for like so:
+When verification of a JWT fails, this library will throw an error. All errors are defined in [src/error.ts](./src/error.ts) and can be imported and tested for like so:
 
 ```typescript
 import { CognitoJwtVerifier } from "aws-jwt-verify";

--- a/README.md
+++ b/README.md
@@ -405,9 +405,12 @@ try {
   );
 } catch (err) {
   if (err instanceof JwtInvalidClaimError) {
-    console.error("JWT invalid:", err.rawJwt.payload);
+    // You can log the payload of the raw JWT, e.g. to aid in debugging and alerting on authentication errors
+    // Be careful not to disclose information on the error reason to the the client
+    console.error("JWT invalid because:", err.message);
+    console.error("Raw JWT:", err.rawJwt.payload);
   }
-  throw err;
+  throw new Error("Unauthorized");
 }
 ```
 
@@ -446,7 +449,7 @@ try {
   if (err instanceof JwtInvalidClaimError) {
     console.error("JWT invalid:", err.rawJwt.payload);
   }
-  throw err;
+  throw new Error("Unauthorized");
 }
 ```
 
@@ -840,7 +843,7 @@ exports.handler = async (event) => {
     await jwtVerifier.verify(accessToken);
   } catch {
     return {
-      isAuthorized: False,
+      isAuthorized: false,
     };
   }
   //Proceed with additional authorization logic

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This library was specifically designed to be easy to use in:
 - [Verifying JWTs from any OIDC-compatible IDP](#verifying-jwts-from-any-oidc-compatible-idp)
   - [Verify parameters](#jwtrsaverifier-verify-parameters)
 - [Verification errors](#verification-errors)
+  - [Peek inside invalid JWTs](#peek-inside-invalid-jwts)
 - [The JWKS cache](#the-jwks-cache)
   - [Loading the JWKS from file](#loading-the-jwks-from-file)
   - [Rate limiting](#rate-limiting)
@@ -141,6 +142,7 @@ Supported parameters are:
 - `scope` (optional): verify that the JWT's `scope` claim matches your expectation (only of use for access tokens). Provide a string, or an array of strings to allow multiple scopes (i.e. one of these scopes must match the JWT). See also [Checking scope](#Checking-scope).
 - `graceSeconds` (optional, default `0`): to account for clock differences between systems, provide the number of seconds beyond JWT expiry (`exp` claim) or before "not before" (`nbf` claim) you will allow.
 - `customJwtCheck` (optional): your custom function with additional JWT (and JWK) checks to execute (see also below).
+- `includeRawJwtInErrors` (optional): set to true if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
 
 ```typescript
 import { CognitoJwtVerifier } from "aws-jwt-verify";
@@ -352,6 +354,7 @@ Supported parameters are:
 - `scope` (optional): verify that the JWT's `scope` claim matches your expectation (only of use for access tokens). Provide a string, or an array of strings to allow multiple scopes (i.e. one of these scopes must match the JWT). See also [Checking scope](#checking-scope).
 - `graceSeconds` (optional, default `0`): to account for clock differences between systems, provide the number of seconds beyond JWT expiry (`exp` claim) or before "not before" (`nbf` claim) you will allow.
 - `customJwtCheck` (optional): your custom function with additional JWT checks to execute (see [Custom JWT and JWK checks](#custom-jwt-and-jwk-checks)).
+- `includeRawJwtInErrors` (optional): set to true if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
 
 ## Verification errors
 
@@ -381,6 +384,8 @@ try {
 }
 ```
 
+### Peek inside invalid JWTs
+
 If you want to peek inside invalid JWTs, set `includeRawJwtInErrors` to `true` when creating the verifier. The thrown error will then include the raw JWT:
 
 ```typescript
@@ -400,7 +405,7 @@ try {
   );
 } catch (err) {
   if (err instanceof JwtInvalidClaimError) {
-    console.error("JWT invalid:", err.rawJwt);
+    console.error("JWT invalid:", err.rawJwt.payload);
   }
   throw err;
 }

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ The `instanceof` check in the `catch` block above is crucial, because not all er
 
 Only in case of stage 3 verification errors, will the raw JWT be included in the error (if you set `includeRawJwtInErrors` to `true`). This way, when you look at the invalid raw JWT in the error, you'll know that its structure and signature are at least valid (stages 1 and 2 succeeded).
 
+Note that if you use [custom JWT checks](#custom-jwt-and-jwk-checks), you are in charge of throwing errors in your custom code. You can (optionally) subclass your errors from `JwtInvalidClaimError`, so that the raw JWT will be included on the errors you throw as well.
+
 ## The JWKS cache
 
 The JWKS cache is responsible for fetching the JWKS from the JWKS URI, caching it, and selecting the right JWK from it. Both the `CognitoJwtVerifier` and the (generic) `JwtRsaVerifier` utilize an in-memory JWKS cache. For each `issuer` a JWKS cache is maintained, and each JWK in a JWKS is selected and cached using its `kid` (key id). The JWKS for an `issuer` will be fetched once initially, and thereafter only upon key rotations (detected by the occurrence of a JWT with a `kid` that is not yet in the cache).

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Supported parameters are:
 - `scope` (optional): verify that the JWT's `scope` claim matches your expectation (only of use for access tokens). Provide a string, or an array of strings to allow multiple scopes (i.e. one of these scopes must match the JWT). See also [Checking scope](#Checking-scope).
 - `graceSeconds` (optional, default `0`): to account for clock differences between systems, provide the number of seconds beyond JWT expiry (`exp` claim) or before "not before" (`nbf` claim) you will allow.
 - `customJwtCheck` (optional): your custom function with additional JWT (and JWK) checks to execute (see also below).
-- `includeRawJwtInErrors` (optional): set to `true` if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
+- `includeRawJwtInErrors` (optional, default `false`): set to `true` if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
 
 ```typescript
 import { CognitoJwtVerifier } from "aws-jwt-verify";
@@ -354,7 +354,7 @@ Supported parameters are:
 - `scope` (optional): verify that the JWT's `scope` claim matches your expectation (only of use for access tokens). Provide a string, or an array of strings to allow multiple scopes (i.e. one of these scopes must match the JWT). See also [Checking scope](#checking-scope).
 - `graceSeconds` (optional, default `0`): to account for clock differences between systems, provide the number of seconds beyond JWT expiry (`exp` claim) or before "not before" (`nbf` claim) you will allow.
 - `customJwtCheck` (optional): your custom function with additional JWT checks to execute (see [Custom JWT and JWK checks](#custom-jwt-and-jwk-checks)).
-- `includeRawJwtInErrors` (optional): set to `true` if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
+- `includeRawJwtInErrors` (optional, default `false`): set to `true` if you want to peek inside the invalid JWT when verification fails. Refer to: [Peek inside invalid JWTs](#peek-inside-invalid-jwts).
 
 ## Verification errors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "aws-jwt-verify",
       "version": "1.0.3",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@tsconfig/node14": "^1.0.1",
         "@types/jest": "^27.0.2",

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -3,7 +3,7 @@
 //
 // Utilities to assert that supplied values match with expected values
 
-import { AssertionErrorConstructor, FailedAssertionError } from "./error";
+import { AssertionErrorConstructor, FailedAssertionError } from "./error.js";
 
 /**
  * Assert value is a non-empty string and equal to the expected value,
@@ -75,12 +75,7 @@ export function assertStringArrayContainsString(
       expected
     );
   }
-  return assertStringArraysOverlap(
-    name,
-    actual,
-    expected,
-    errorConstructor
-  );
+  return assertStringArraysOverlap(name, actual, expected, errorConstructor);
 }
 
 /**
@@ -114,11 +109,7 @@ export function assertStringArraysOverlap(
     actual = [actual];
   }
   if (!Array.isArray(actual)) {
-    throw new errorConstructor(
-      `${name} is not an array`,
-      actual,
-      expected
-    );
+    throw new errorConstructor(`${name} is not an array`, actual, expected);
   }
   const overlaps = actual.some((actualItem) => {
     if (typeof actualItem !== "string") {

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -9,34 +9,34 @@ import { AssertionErrorConstructor, FailedAssertionError } from "./error";
  * Assert value is a non-empty string and equal to the expected value,
  * or throw an error otherwise
  *
- * @param displayName - Name for the value being checked
+ * @param name - Name for the value being checked
  * @param actual - The value to check
  * @param expected - The expected value
  * @param errorConstructor - Constructor for the concrete error to be thrown
  */
 export function assertStringEquals(
-  displayName: string,
+  name: string,
   actual: unknown,
   expected: string,
   errorConstructor: AssertionErrorConstructor = FailedAssertionError
 ): void {
   if (!actual) {
     throw new errorConstructor(
-      `Missing ${displayName}. Expected: ${expected}`,
+      `Missing ${name}. Expected: ${expected}`,
       actual,
       expected
     );
   }
   if (typeof actual !== "string") {
     throw new errorConstructor(
-      `${displayName} is not of type string`,
+      `${name} is not of type string`,
       actual,
       expected
     );
   }
   if (expected !== actual) {
     throw new errorConstructor(
-      `${displayName} not allowed: ${actual}. Expected: ${expected}`,
+      `${name} not allowed: ${actual}. Expected: ${expected}`,
       actual,
       expected
     );
@@ -47,21 +47,21 @@ export function assertStringEquals(
  * Assert value is a non-empty string and is indeed one of the expected values,
  * or throw an error otherwise
  *
- * @param displayName - Name for the value being checked
+ * @param name - Name for the value being checked
  * @param actual - The value to check
  * @param expected - The array of expected values. For your convenience you can provide
  * @param errorConstructor - Constructor for the concrete error to be thrown
  * a string here as well, which will mean an array with just that string
  */
 export function assertStringArrayContainsString(
-  displayName: string,
+  name: string,
   actual: unknown,
   expected: string | string[],
   errorConstructor: AssertionErrorConstructor = FailedAssertionError
 ): void {
   if (!actual) {
     throw new errorConstructor(
-      `Missing ${displayName}. ${expectationMessage(expected)}`,
+      `Missing ${name}. ${expectationMessage(expected)}`,
 
       actual,
       expected
@@ -69,14 +69,14 @@ export function assertStringArrayContainsString(
   }
   if (typeof actual !== "string") {
     throw new errorConstructor(
-      `${displayName} is not of type string`,
+      `${name} is not of type string`,
 
       actual,
       expected
     );
   }
   return assertStringArraysOverlap(
-    displayName,
+    name,
     actual,
     expected,
     errorConstructor
@@ -87,7 +87,7 @@ export function assertStringArrayContainsString(
  * Assert value is an array of strings, where at least one of the strings is indeed one of the expected values,
  * or throw an error otherwise
  *
- * @param displayName - Name for the value being checked
+ * @param name - Name for the value being checked
  * @param actual - The value to check, must be an array of strings, or a single string (which will be treated
  * as an array with just that string)
  * @param expected - The array of expected values. For your convenience you can provide
@@ -95,14 +95,14 @@ export function assertStringArrayContainsString(
  * @param errorConstructor - Constructor for the concrete error to be thrown
  */
 export function assertStringArraysOverlap(
-  displayName: string,
+  name: string,
   actual: unknown,
   expected: string | string[],
   errorConstructor: AssertionErrorConstructor = FailedAssertionError
 ): void {
   if (!actual) {
     throw new errorConstructor(
-      `Missing ${displayName}. ${expectationMessage(expected)}`,
+      `Missing ${name}. ${expectationMessage(expected)}`,
       actual,
       expected
     );
@@ -115,7 +115,7 @@ export function assertStringArraysOverlap(
   }
   if (!Array.isArray(actual)) {
     throw new errorConstructor(
-      `${displayName} is not an array`,
+      `${name} is not an array`,
       actual,
       expected
     );
@@ -123,7 +123,7 @@ export function assertStringArraysOverlap(
   const overlaps = actual.some((actualItem) => {
     if (typeof actualItem !== "string") {
       throw new errorConstructor(
-        `${displayName} includes elements that are not of type string`,
+        `${name} includes elements that are not of type string`,
         actual,
         expected
       );
@@ -132,7 +132,7 @@ export function assertStringArraysOverlap(
   });
   if (!overlaps) {
     throw new errorConstructor(
-      `${displayName} not allowed: ${actual.join(", ")}. ${expectationMessage(
+      `${name} not allowed: ${actual.join(", ")}. ${expectationMessage(
         expected
       )}`,
       actual,

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -3,50 +3,45 @@
 //
 // Utilities to assert that supplied values match with expected values
 
-interface AssertionErrorConstructor<ErrorType extends Error> {
-  new (
-    msg: string,
-    name: string,
-    actual: unknown,
-    expected: string | string[]
-  ): ErrorType;
-}
+import { AssertionErrorConstructor, AssertedClaim } from "./error.js";
 
 /**
  * Assert value is a non-empty string and equal to the expected value,
  * or throw an error otherwise
  *
  * @param errorConstructor - Constructor for the concrete error to be thrown
- * @param name - Name for the value being checked
+ * @param displayName - Name for the value being checked
+ * @param assertedClaim - The claim that is being checked
  * @param actual - The value to check
  * @param expected - The expected value
  */
-export function assertStringEquals<ErrorType extends Error>(
-  errorConstructor: AssertionErrorConstructor<ErrorType>,
-  name: string,
+export function assertStringEquals(
+  errorConstructor: AssertionErrorConstructor,
+  displayName: string,
+  assertedClaim: AssertedClaim,
   actual: unknown,
   expected: string
 ): void {
   if (!actual) {
     throw new errorConstructor(
-      `Missing ${name}. Expected: ${expected}`,
-      name,
+      `Missing ${displayName}. Expected: ${expected}`,
+      assertedClaim,
       actual,
       expected
     );
   }
   if (typeof actual !== "string") {
     throw new errorConstructor(
-      `${name} is not of type string`,
-      name,
+      `${displayName} is not of type string`,
+      assertedClaim,
       actual,
       expected
     );
   }
   if (expected !== actual) {
     throw new errorConstructor(
-      `${name} not allowed: ${actual}. Expected: ${expected}`,
-      name,
+      `${displayName} not allowed: ${actual}. Expected: ${expected}`,
+      assertedClaim,
       actual,
       expected
     );
@@ -58,34 +53,42 @@ export function assertStringEquals<ErrorType extends Error>(
  * or throw an error otherwise
  *
  * @param errorConstructor - Constructor for the concrete error to be thrown
- * @param name - Name for the value being checked
+ * @param displayName - Name for the value being checked
+ * @param assertedClaim - The claim that is being checked
  * @param actual - The value to check
  * @param expected - The array of expected values. For your convenience you can provide
  * a string here as well, which will mean an array with just that string
  */
-export function assertStringArrayContainsString<ErrorType extends Error>(
-  errorConstructor: AssertionErrorConstructor<ErrorType>,
-  name: string,
+export function assertStringArrayContainsString(
+  errorConstructor: AssertionErrorConstructor,
+  displayName: string,
+  assertedClaim: AssertedClaim,
   actual: unknown,
   expected: string | string[]
 ): void {
   if (!actual) {
     throw new errorConstructor(
-      `Missing ${name}. ${expectationMessage(expected)}`,
-      name,
+      `Missing ${displayName}. ${expectationMessage(expected)}`,
+      assertedClaim,
       actual,
       expected
     );
   }
   if (typeof actual !== "string") {
     throw new errorConstructor(
-      `${name} is not of type string`,
-      name,
+      `${displayName} is not of type string`,
+      assertedClaim,
       actual,
       expected
     );
   }
-  return assertStringArraysOverlap(errorConstructor, name, actual, expected);
+  return assertStringArraysOverlap(
+    errorConstructor,
+    displayName,
+    assertedClaim,
+    actual,
+    expected
+  );
 }
 
 /**
@@ -93,22 +96,24 @@ export function assertStringArrayContainsString<ErrorType extends Error>(
  * or throw an error otherwise
  *
  * @param errorConstructor - Constructor for the concrete error to be thrown
- * @param name - Name for the value being checked
+ * @param displayName - Name for the value being checked
+ * @param assertedClaim - The claim that is being checked
  * @param actual - The value to check, must be an array of strings, or a single string (which will be treated
  * as an array with just that string)
  * @param expected - The array of expected values. For your convenience you can provide
  * a string here as well, which will mean an array with just that string
  */
-export function assertStringArraysOverlap<ErrorType extends Error>(
-  errorConstructor: AssertionErrorConstructor<ErrorType>,
-  name: string,
+export function assertStringArraysOverlap(
+  errorConstructor: AssertionErrorConstructor,
+  displayName: string,
+  assertedClaim: AssertedClaim,
   actual: unknown,
   expected: string | string[]
 ): void {
   if (!actual) {
     throw new errorConstructor(
-      `Missing ${name}. ${expectationMessage(expected)}`,
-      name,
+      `Missing ${displayName}. ${expectationMessage(expected)}`,
+      assertedClaim,
       actual,
       expected
     );
@@ -121,8 +126,8 @@ export function assertStringArraysOverlap<ErrorType extends Error>(
   }
   if (!Array.isArray(actual)) {
     throw new errorConstructor(
-      `${name} is not an array`,
-      name,
+      `${displayName} is not an array`,
+      assertedClaim,
       actual,
       expected
     );
@@ -130,8 +135,8 @@ export function assertStringArraysOverlap<ErrorType extends Error>(
   const overlaps = actual.some((actualItem) => {
     if (typeof actualItem !== "string") {
       throw new errorConstructor(
-        `${name} includes elements that are not of type string`,
-        name,
+        `${displayName} includes elements that are not of type string`,
+        assertedClaim,
         actual,
         expected
       );
@@ -140,10 +145,10 @@ export function assertStringArraysOverlap<ErrorType extends Error>(
   });
   if (!overlaps) {
     throw new errorConstructor(
-      `${name} not allowed: ${actual.join(", ")}. ${expectationMessage(
+      `${displayName} not allowed: ${actual.join(", ")}. ${expectationMessage(
         expected
       )}`,
-      name,
+      assertedClaim,
       actual,
       expected
     );

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -3,29 +3,26 @@
 //
 // Utilities to assert that supplied values match with expected values
 
-import { AssertionErrorConstructor, AssertedClaim } from "./error.js";
+import { AssertionErrorConstructor, FailedAssertionError } from "./error";
 
 /**
  * Assert value is a non-empty string and equal to the expected value,
  * or throw an error otherwise
  *
- * @param errorConstructor - Constructor for the concrete error to be thrown
  * @param displayName - Name for the value being checked
- * @param assertedClaim - The claim that is being checked
  * @param actual - The value to check
  * @param expected - The expected value
+ * @param errorConstructor - Constructor for the concrete error to be thrown
  */
 export function assertStringEquals(
-  errorConstructor: AssertionErrorConstructor,
   displayName: string,
-  assertedClaim: AssertedClaim,
   actual: unknown,
-  expected: string
+  expected: string,
+  errorConstructor: AssertionErrorConstructor = FailedAssertionError
 ): void {
   if (!actual) {
     throw new errorConstructor(
       `Missing ${displayName}. Expected: ${expected}`,
-      assertedClaim,
       actual,
       expected
     );
@@ -33,7 +30,6 @@ export function assertStringEquals(
   if (typeof actual !== "string") {
     throw new errorConstructor(
       `${displayName} is not of type string`,
-      assertedClaim,
       actual,
       expected
     );
@@ -41,7 +37,6 @@ export function assertStringEquals(
   if (expected !== actual) {
     throw new errorConstructor(
       `${displayName} not allowed: ${actual}. Expected: ${expected}`,
-      assertedClaim,
       actual,
       expected
     );
@@ -52,24 +47,22 @@ export function assertStringEquals(
  * Assert value is a non-empty string and is indeed one of the expected values,
  * or throw an error otherwise
  *
- * @param errorConstructor - Constructor for the concrete error to be thrown
  * @param displayName - Name for the value being checked
- * @param assertedClaim - The claim that is being checked
  * @param actual - The value to check
  * @param expected - The array of expected values. For your convenience you can provide
+ * @param errorConstructor - Constructor for the concrete error to be thrown
  * a string here as well, which will mean an array with just that string
  */
 export function assertStringArrayContainsString(
-  errorConstructor: AssertionErrorConstructor,
   displayName: string,
-  assertedClaim: AssertedClaim,
   actual: unknown,
-  expected: string | string[]
+  expected: string | string[],
+  errorConstructor: AssertionErrorConstructor = FailedAssertionError
 ): void {
   if (!actual) {
     throw new errorConstructor(
       `Missing ${displayName}. ${expectationMessage(expected)}`,
-      assertedClaim,
+
       actual,
       expected
     );
@@ -77,17 +70,16 @@ export function assertStringArrayContainsString(
   if (typeof actual !== "string") {
     throw new errorConstructor(
       `${displayName} is not of type string`,
-      assertedClaim,
+
       actual,
       expected
     );
   }
   return assertStringArraysOverlap(
-    errorConstructor,
     displayName,
-    assertedClaim,
     actual,
-    expected
+    expected,
+    errorConstructor
   );
 }
 
@@ -95,25 +87,22 @@ export function assertStringArrayContainsString(
  * Assert value is an array of strings, where at least one of the strings is indeed one of the expected values,
  * or throw an error otherwise
  *
- * @param errorConstructor - Constructor for the concrete error to be thrown
  * @param displayName - Name for the value being checked
- * @param assertedClaim - The claim that is being checked
  * @param actual - The value to check, must be an array of strings, or a single string (which will be treated
  * as an array with just that string)
  * @param expected - The array of expected values. For your convenience you can provide
  * a string here as well, which will mean an array with just that string
+ * @param errorConstructor - Constructor for the concrete error to be thrown
  */
 export function assertStringArraysOverlap(
-  errorConstructor: AssertionErrorConstructor,
   displayName: string,
-  assertedClaim: AssertedClaim,
   actual: unknown,
-  expected: string | string[]
+  expected: string | string[],
+  errorConstructor: AssertionErrorConstructor = FailedAssertionError
 ): void {
   if (!actual) {
     throw new errorConstructor(
       `Missing ${displayName}. ${expectationMessage(expected)}`,
-      assertedClaim,
       actual,
       expected
     );
@@ -127,7 +116,6 @@ export function assertStringArraysOverlap(
   if (!Array.isArray(actual)) {
     throw new errorConstructor(
       `${displayName} is not an array`,
-      assertedClaim,
       actual,
       expected
     );
@@ -136,7 +124,6 @@ export function assertStringArraysOverlap(
     if (typeof actualItem !== "string") {
       throw new errorConstructor(
         `${displayName} includes elements that are not of type string`,
-        assertedClaim,
         actual,
         expected
       );
@@ -148,7 +135,6 @@ export function assertStringArraysOverlap(
       `${displayName} not allowed: ${actual.join(", ")}. ${expectationMessage(
         expected
       )}`,
-      assertedClaim,
       actual,
       expected
     );

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -3,30 +3,52 @@
 //
 // Utilities to assert that supplied values match with expected values
 
-import { AssertionError } from "./error.js";
+interface AssertionErrorConstructor<ErrorType extends Error> {
+  new (
+    msg: string,
+    name: string,
+    actual: unknown,
+    expected: string | string[]
+  ): ErrorType;
+}
 
 /**
  * Assert value is a non-empty string and equal to the expected value,
  * or throw an error otherwise
  *
+ * @param errorConstructor - Constructor for the concrete error to be thrown
  * @param name - Name for the value being checked
  * @param actual - The value to check
  * @param expected - The expected value
  */
-export function assertStringEquals(
+export function assertStringEquals<ErrorType extends Error>(
+  errorConstructor: AssertionErrorConstructor<ErrorType>,
   name: string,
   actual: unknown,
   expected: string
 ): void {
   if (!actual) {
-    throw new AssertionError(`Missing ${name}. Expected: ${expected}`);
+    throw new errorConstructor(
+      `Missing ${name}. Expected: ${expected}`,
+      name,
+      actual,
+      expected
+    );
   }
   if (typeof actual !== "string") {
-    throw new AssertionError(`${name} is not of type string`);
+    throw new errorConstructor(
+      `${name} is not of type string`,
+      name,
+      actual,
+      expected
+    );
   }
   if (expected !== actual) {
-    throw new AssertionError(
-      `${name} not allowed: ${actual}. Expected: ${expected}`
+    throw new errorConstructor(
+      `${name} not allowed: ${actual}. Expected: ${expected}`,
+      name,
+      actual,
+      expected
     );
   }
 }
@@ -35,45 +57,60 @@ export function assertStringEquals(
  * Assert value is a non-empty string and is indeed one of the expected values,
  * or throw an error otherwise
  *
+ * @param errorConstructor - Constructor for the concrete error to be thrown
  * @param name - Name for the value being checked
  * @param actual - The value to check
  * @param expected - The array of expected values. For your convenience you can provide
  * a string here as well, which will mean an array with just that string
  */
-export function assertStringArrayContainsString(
+export function assertStringArrayContainsString<ErrorType extends Error>(
+  errorConstructor: AssertionErrorConstructor<ErrorType>,
   name: string,
   actual: unknown,
   expected: string | string[]
 ): void {
   if (!actual) {
-    throw new AssertionError(
-      `Missing ${name}. ${expectationMessage(expected)}`
+    throw new errorConstructor(
+      `Missing ${name}. ${expectationMessage(expected)}`,
+      name,
+      actual,
+      expected
     );
   }
   if (typeof actual !== "string") {
-    throw new AssertionError(`${name} is not of type string`);
+    throw new errorConstructor(
+      `${name} is not of type string`,
+      name,
+      actual,
+      expected
+    );
   }
-  return assertStringArraysOverlap(name, actual, expected);
+  return assertStringArraysOverlap(errorConstructor, name, actual, expected);
 }
 
 /**
  * Assert value is an array of strings, where at least one of the strings is indeed one of the expected values,
  * or throw an error otherwise
  *
+ * @param errorConstructor - Constructor for the concrete error to be thrown
  * @param name - Name for the value being checked
  * @param actual - The value to check, must be an array of strings, or a single string (which will be treated
  * as an array with just that string)
  * @param expected - The array of expected values. For your convenience you can provide
  * a string here as well, which will mean an array with just that string
  */
-export function assertStringArraysOverlap(
+export function assertStringArraysOverlap<ErrorType extends Error>(
+  errorConstructor: AssertionErrorConstructor<ErrorType>,
   name: string,
   actual: unknown,
   expected: string | string[]
 ): void {
   if (!actual) {
-    throw new AssertionError(
-      `Missing ${name}. ${expectationMessage(expected)}`
+    throw new errorConstructor(
+      `Missing ${name}. ${expectationMessage(expected)}`,
+      name,
+      actual,
+      expected
     );
   }
   const expectedAsSet = new Set(
@@ -83,21 +120,32 @@ export function assertStringArraysOverlap(
     actual = [actual];
   }
   if (!Array.isArray(actual)) {
-    throw new AssertionError(`${name} is not an array`);
+    throw new errorConstructor(
+      `${name} is not an array`,
+      name,
+      actual,
+      expected
+    );
   }
   const overlaps = actual.some((actualItem) => {
     if (typeof actualItem !== "string") {
-      throw new AssertionError(
-        `${name} includes elements that are not of type string`
+      throw new errorConstructor(
+        `${name} includes elements that are not of type string`,
+        name,
+        actual,
+        expected
       );
     }
     return expectedAsSet.has(actualItem);
   });
   if (!overlaps) {
-    throw new AssertionError(
+    throw new errorConstructor(
       `${name} not allowed: ${actual.join(", ")}. ${expectationMessage(
         expected
-      )}`
+      )}`,
+      name,
+      actual,
+      expected
     );
   }
 }

--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -156,21 +156,19 @@ function validateCognitoJwtFields(
   // Check groups
   if (options.groups != null) {
     assertStringArraysOverlap(
-      CognitoJwtInvalidGroupError,
       "Cognito group",
-      "payload.cognito:groups",
       payload["cognito:groups"],
-      options.groups
+      options.groups,
+      CognitoJwtInvalidGroupError
     );
   }
 
   // Check token use
   assertStringArrayContainsString(
-    CognitoJwtInvalidTokenUseError,
     "Token use",
-    "payload.token_use",
     payload.token_use,
-    ["id", "access"]
+    ["id", "access"],
+    CognitoJwtInvalidTokenUseError
   );
   if (options.tokenUse !== null) {
     if (options.tokenUse === undefined) {
@@ -179,11 +177,10 @@ function validateCognitoJwtFields(
       );
     }
     assertStringEquals(
-      CognitoJwtInvalidTokenUseError,
       "Token use",
-      "payload.token_use",
       payload.token_use,
-      options.tokenUse
+      options.tokenUse,
+      CognitoJwtInvalidTokenUseError
     );
   }
 
@@ -196,19 +193,17 @@ function validateCognitoJwtFields(
     }
     if (payload.token_use === "id") {
       assertStringArrayContainsString(
-        CognitoJwtInvalidClientIdError,
         'Client ID ("audience")',
-        "payload.aud",
         payload.aud,
-        options.clientId
+        options.clientId,
+        CognitoJwtInvalidClientIdError
       );
     } else {
       assertStringArrayContainsString(
-        CognitoJwtInvalidClientIdError,
         "Client ID",
-        "payload.client_id",
         payload.client_id,
-        options.clientId
+        options.clientId,
+        CognitoJwtInvalidClientIdError
       );
     }
   }

--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -312,10 +312,10 @@ export class CognitoJwtVerifier<
    * @returns The payload of the JWT––if the JWT is valid, otherwise an error is thrown
    */
   public verifySync<T extends SpecificVerifyProperties>(
-    ...args: CognitoVerifyParameters<SpecificVerifyProperties>
+    ...[jwt, properties]: CognitoVerifyParameters<SpecificVerifyProperties>
   ): CognitoIdOrAccessTokenPayload<IssuerConfig, T> {
     const { decomposedJwt, jwksUri, verifyProperties } =
-      this.getVerifyParameters(args[0], args[1]);
+      this.getVerifyParameters(jwt, properties);
     this.verifyDecomposedJwtSync(decomposedJwt, jwksUri, verifyProperties);
     try {
       validateCognitoJwtFields(decomposedJwt.payload, verifyProperties);
@@ -344,10 +344,10 @@ export class CognitoJwtVerifier<
    * @returns Promise that resolves to the payload of the JWT––if the JWT is valid, otherwise the promise rejects
    */
   public async verify<T extends SpecificVerifyProperties>(
-    ...args: CognitoVerifyParameters<SpecificVerifyProperties>
+    ...[jwt, properties]: CognitoVerifyParameters<SpecificVerifyProperties>
   ): Promise<CognitoIdOrAccessTokenPayload<IssuerConfig, T>> {
     const { decomposedJwt, jwksUri, verifyProperties } =
-      this.getVerifyParameters(args[0], args[1]);
+      this.getVerifyParameters(jwt, properties);
     await this.verifyDecomposedJwt(decomposedJwt, jwksUri, verifyProperties);
     try {
       validateCognitoJwtFields(decomposedJwt.payload, verifyProperties);
@@ -378,17 +378,17 @@ export class CognitoJwtVerifier<
    * @returns void
    */
   public cacheJwks(
-    ...args: MultiIssuer extends false
+    ...[jwks, userPoolId]: MultiIssuer extends false
       ? [jwks: Jwks, userPoolId?: string]
       : [jwks: Jwks, userPoolId: string]
   ): void {
     let issuer: string | undefined;
-    if (args[1] !== undefined) {
-      issuer = CognitoJwtVerifier.parseUserPoolId(args[1]).issuer;
+    if (userPoolId !== undefined) {
+      issuer = CognitoJwtVerifier.parseUserPoolId(userPoolId).issuer;
     } else if (this.expectedIssuers.length > 1) {
       throw new ParameterValidationError("userPoolId must be provided");
     }
     const issuerConfig = this.getIssuerConfig(issuer);
-    super.cacheJwks(args[0], issuerConfig.issuer);
+    super.cacheJwks(jwks, issuerConfig.issuer);
   }
 }

--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -69,10 +69,10 @@ interface CognitoVerifyProperties {
     jwk: Jwk;
   }) => Promise<void> | void;
   /**
-   * If you want to access the JWT when verification fails, set this to true.
-   * Then, if an error is thrown during verification, the Error object will include a property `rawJwt`
-   * with the (decoded) contents of the JWT. (Only if the JWT was syntactically valid and could be decoded)
-   * !!! Do NOT trust the content of a JWT that failed verification !!!
+   * If you want to peek inside the invalid JWT when verification fails, set `includeRawJwtInErrors` to true.
+   * Then, if an error is thrown during verification of the invalid JWT (e.g. the JWT is invalid because it is expired),
+   * the Error object will include a property `rawJwt`, with the raw decoded contents of the **invalid** JWT.
+   * The `rawJwt` will only be included in the Error object, if the JWT's signature can at least be verified.
    */
   includeRawJwtInErrors?: boolean;
 }
@@ -158,6 +158,7 @@ function validateCognitoJwtFields(
     assertStringArraysOverlap(
       CognitoJwtInvalidGroupError,
       "Cognito group",
+      "payload.cognito:groups",
       payload["cognito:groups"],
       options.groups
     );
@@ -167,6 +168,7 @@ function validateCognitoJwtFields(
   assertStringArrayContainsString(
     CognitoJwtInvalidTokenUseError,
     "Token use",
+    "payload.token_use",
     payload.token_use,
     ["id", "access"]
   );
@@ -179,6 +181,7 @@ function validateCognitoJwtFields(
     assertStringEquals(
       CognitoJwtInvalidTokenUseError,
       "Token use",
+      "payload.token_use",
       payload.token_use,
       options.tokenUse
     );
@@ -195,6 +198,7 @@ function validateCognitoJwtFields(
       assertStringArrayContainsString(
         CognitoJwtInvalidClientIdError,
         'Client ID ("audience")',
+        "payload.aud",
         payload.aud,
         options.clientId
       );
@@ -202,6 +206,7 @@ function validateCognitoJwtFields(
       assertStringArrayContainsString(
         CognitoJwtInvalidClientIdError,
         "Client ID",
+        "payload.client_id",
         payload.client_id,
         options.clientId
       );

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { DecomposedJwt } from "./jwt";
+
 export abstract class JwtBaseError extends Error {}
 
 /**
@@ -22,7 +24,47 @@ export class JwtNotBeforeError extends JwtBaseError {}
 
 export class ParameterValidationError extends JwtBaseError {}
 
-export class JwtInvalidClaimError extends JwtBaseError {}
+export abstract class JwtInvalidClaimError extends JwtBaseError {
+  public failedAssertion: {
+    name: string;
+    actual: unknown;
+    expected: string | string[];
+  };
+  public rawJwt?: DecomposedJwt;
+  constructor(
+    msg: string,
+    name: string,
+    actual: unknown,
+    expected: string | string[]
+  ) {
+    super(msg);
+    this.failedAssertion = { name, actual, expected };
+  }
+  public withRawJwt(rawJwt: DecomposedJwt): JwtInvalidClaimError {
+    this.rawJwt = rawJwt;
+    return this;
+  }
+}
+
+export class JwtInvalidIssuerError extends JwtInvalidClaimError {}
+
+export class JwtInvalidAudienceError extends JwtInvalidClaimError {}
+
+export class JwtInvalidScopeError extends JwtInvalidClaimError {}
+
+export class JwtInvalidSignatureAlgorithmError extends JwtInvalidClaimError {}
+
+export class JwtInvalidJwkError extends JwtInvalidClaimError {}
+
+/**
+ * Amazon Cognito specific erros
+ */
+
+export class CognitoJwtInvalidGroupError extends JwtInvalidClaimError {}
+
+export class CognitoJwtInvalidTokenUseError extends JwtInvalidClaimError {}
+
+export class CognitoJwtInvalidClientIdError extends JwtInvalidClaimError {}
 
 /**
  * ASN.1 errors
@@ -57,9 +99,3 @@ export class FetchError extends JwtBaseError {
 }
 
 export class NonRetryableFetchError extends FetchError {}
-
-/**
- * Assertion errors
- */
-
-export class AssertionError extends JwtBaseError {}

--- a/src/jwt-model.ts
+++ b/src/jwt-model.ts
@@ -22,6 +22,11 @@ interface JwtPayloadStandardFields {
 
 export type JwtPayload = JwtPayloadStandardFields & JsonObject;
 
+export interface Jwt {
+  header: JwtHeader;
+  payload: JwtPayload;
+}
+
 export type CognitoIdOrAccessTokenPayload<IssuerConfig, VerifyProps> =
   VerifyProps extends { tokenUse: null }
     ? CognitoJwtPayload
@@ -79,3 +84,8 @@ interface CognitoAccessTokenFields extends CognitoJwtFields {
 }
 
 export type CognitoAccessTokenPayload = CognitoAccessTokenFields & JsonObject;
+
+export interface CognitoJwt {
+  header: JwtHeader;
+  payload: CognitoAccessTokenPayload | CognitoIdTokenPayload;
+}

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -498,12 +498,12 @@ export abstract class JwtRsaVerifierBase<
    * @returns void
    */
   public cacheJwks(
-    ...args: MultiIssuer extends false
+    ...[jwks, issuer]: MultiIssuer extends false
       ? [jwks: Jwks, issuer?: string]
       : [jwks: Jwks, issuer: string]
   ): void {
-    const issuerConfig = this.getIssuerConfig(args[1]);
-    this.jwksCache.addJwks(issuerConfig.jwksUri, args[0]);
+    const issuerConfig = this.getIssuerConfig(issuer);
+    this.jwksCache.addJwks(issuerConfig.jwksUri, jwks);
     this.publicKeyCache.clearCache(issuerConfig.issuer);
   }
 
@@ -529,10 +529,10 @@ export abstract class JwtRsaVerifierBase<
    * @returns The payload of the JWT––if the JWT is valid, otherwise an error is thrown
    */
   public verifySync(
-    ...args: VerifyParameters<SpecificVerifyProperties>
+    ...[jwt, properties]: VerifyParameters<SpecificVerifyProperties>
   ): JwtPayload {
     const { decomposedJwt, jwksUri, verifyProperties } =
-      this.getVerifyParameters(args[0], args[1]);
+      this.getVerifyParameters(jwt, properties);
     return this.verifyDecomposedJwtSync(
       decomposedJwt,
       jwksUri,
@@ -572,10 +572,10 @@ export abstract class JwtRsaVerifierBase<
    * @returns Promise that resolves to the payload of the JWT––if the JWT is valid, otherwise the promise rejects
    */
   public async verify(
-    ...args: VerifyParameters<SpecificVerifyProperties>
+    ...[jwt, properties]: VerifyParameters<SpecificVerifyProperties>
   ): Promise<JwtPayload> {
     const { decomposedJwt, jwksUri, verifyProperties } =
-      this.getVerifyParameters(args[0], args[1]);
+      this.getVerifyParameters(jwt, properties);
     return this.verifyDecomposedJwt(decomposedJwt, jwksUri, verifyProperties);
   }
 

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -287,15 +287,14 @@ async function verifyDecomposedJwt(
 
   try {
     validateJwtFields(payload, options);
+    if (options.customJwtCheck) {
+      await options.customJwtCheck({ header, payload, jwk });
+    }
   } catch (err) {
     if (options.includeRawJwtInErrors && err instanceof JwtInvalidClaimError) {
       throw err.withRawJwt(decomposedJwt);
     }
     throw err;
-  }
-
-  if (options.customJwtCheck) {
-    await options.customJwtCheck({ header, payload, jwk });
   }
 
   return payload;

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -166,29 +166,27 @@ function verifySignatureAgainstJwk(
   jwkToKeyObjectTransformer: JwkToKeyObjectTransformer = transformJwkToKeyObject
 ) {
   // Check JWK use
-  assertStringEquals(JwkInvalidUseError, "JWK use", "jwk.use", jwk.use, "sig");
+  assertStringEquals("JWK use", jwk.use, "sig", JwkInvalidUseError);
 
   // Check JWK kty
-  assertStringEquals(JwkInvalidKtyError, "JWK kty", "jwk.kty", jwk.kty, "RSA");
+  assertStringEquals("JWK kty", jwk.kty, "RSA", JwkInvalidKtyError);
 
   // Check that JWT signature algorithm matches JWK
   if (jwk.alg) {
     assertStringEquals(
-      JwtInvalidSignatureAlgorithmError,
       "JWT signature algorithm",
-      "header.alg",
       header.alg,
-      jwk.alg
+      jwk.alg,
+      JwtInvalidSignatureAlgorithmError
     );
   }
 
   // Check JWT signature algorithm is RS256
   assertStringEquals(
-    JwtInvalidSignatureAlgorithmError,
     "JWT signature algorithm",
-    "header.alg",
     header.alg,
-    "RS256"
+    "RS256",
+    JwtInvalidSignatureAlgorithmError
   );
 
   // Convert JWK modulus and exponent into DER public key
@@ -621,11 +619,10 @@ export abstract class JwtRsaVerifierBase<
   } {
     const decomposedJwt = decomposeJwt(jwt);
     assertStringArrayContainsString(
-      JwtInvalidIssuerError,
       "Issuer",
-      "payload.iss",
       decomposedJwt.payload.iss,
-      this.expectedIssuers
+      this.expectedIssuers,
+      JwtInvalidIssuerError
     );
     const issuerConfig = this.getIssuerConfig(decomposedJwt.payload.iss);
     return {

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -395,20 +395,19 @@ function verifyDecomposedJwtSync(
 
   try {
     validateJwtFields(payload, options);
+    if (options.customJwtCheck) {
+      const res = options.customJwtCheck({ header, payload, jwk });
+      if (res !== undefined && (res as unknown) instanceof Promise) {
+        throw new ParameterValidationError(
+          "Custom JWT checks must be synchronous but a promise was returned"
+        );
+      }
+    }
   } catch (err) {
     if (options.includeRawJwtInErrors && err instanceof JwtInvalidClaimError) {
       throw err.withRawJwt(decomposedJwt);
     }
     throw err;
-  }
-
-  if (options.customJwtCheck) {
-    const res = options.customJwtCheck({ header, payload, jwk });
-    if (res !== undefined && (res as unknown) instanceof Promise) {
-      throw new ParameterValidationError(
-        "Custom JWT checks must be synchronous but a promise was returned"
-      );
-    }
   }
 
   return payload;

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -171,7 +171,9 @@ export function validateJwtFields(
   if (payload.exp !== undefined) {
     if (payload.exp + (options.graceSeconds ?? 0) < Date.now() / 1000) {
       throw new JwtExpiredError(
-        `Token expired at ${new Date(payload.exp * 1000).toISOString()}`
+        `Token expired at ${new Date(payload.exp * 1000).toISOString()}`,
+        "payload.exp",
+        payload.exp
       );
     }
   }
@@ -182,7 +184,9 @@ export function validateJwtFields(
       throw new JwtNotBeforeError(
         `Token can't be used before ${new Date(
           payload.nbf * 1000
-        ).toISOString()}`
+        ).toISOString()}`,
+        "payload.nbf",
+        payload.nbf
       );
     }
   }
@@ -197,6 +201,7 @@ export function validateJwtFields(
     assertStringArrayContainsString(
       JwtInvalidIssuerError,
       "Issuer",
+      "payload.iss",
       payload.iss,
       options.issuer
     );
@@ -212,6 +217,7 @@ export function validateJwtFields(
     assertStringArraysOverlap(
       JwtInvalidAudienceError,
       "Audience",
+      "payload.aud",
       payload.aud,
       options.audience
     );
@@ -222,6 +228,7 @@ export function validateJwtFields(
     assertStringArraysOverlap(
       JwtInvalidScopeError,
       "Scope",
+      "payload.scope",
       payload.scope?.split(" "),
       options.scope
     );

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -172,7 +172,6 @@ export function validateJwtFields(
     if (payload.exp + (options.graceSeconds ?? 0) < Date.now() / 1000) {
       throw new JwtExpiredError(
         `Token expired at ${new Date(payload.exp * 1000).toISOString()}`,
-        "payload.exp",
         payload.exp
       );
     }
@@ -185,7 +184,6 @@ export function validateJwtFields(
         `Token can't be used before ${new Date(
           payload.nbf * 1000
         ).toISOString()}`,
-        "payload.nbf",
         payload.nbf
       );
     }
@@ -199,11 +197,10 @@ export function validateJwtFields(
       );
     }
     assertStringArrayContainsString(
-      JwtInvalidIssuerError,
       "Issuer",
-      "payload.iss",
       payload.iss,
-      options.issuer
+      options.issuer,
+      JwtInvalidIssuerError
     );
   }
 
@@ -215,22 +212,20 @@ export function validateJwtFields(
       );
     }
     assertStringArraysOverlap(
-      JwtInvalidAudienceError,
       "Audience",
-      "payload.aud",
       payload.aud,
-      options.audience
+      options.audience,
+      JwtInvalidAudienceError
     );
   }
 
   // Check scope
   if (options.scope != null) {
     assertStringArraysOverlap(
-      JwtInvalidScopeError,
       "Scope",
-      "payload.scope",
       payload.scope?.split(" "),
-      options.scope
+      options.scope,
+      JwtInvalidScopeError
     );
   }
 }

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -10,6 +10,9 @@ import { safeJsonParse, isJsonObject } from "./safe-json-parse.js";
 import {
   JwtExpiredError,
   JwtNotBeforeError,
+  JwtInvalidIssuerError,
+  JwtInvalidAudienceError,
+  JwtInvalidScopeError,
   JwtParseError,
   ParameterValidationError,
 } from "./error.js";
@@ -146,6 +149,8 @@ export function decomposeJwt(jwt: unknown): {
   };
 }
 
+export type DecomposedJwt = ReturnType<typeof decomposeJwt>;
+
 /**
  * Validate JWT payload fields. Throws an error in case there's any validation issue.
  *
@@ -189,7 +194,12 @@ export function validateJwtFields(
         "issuer must be provided or set to null explicitly"
       );
     }
-    assertStringArrayContainsString("Issuer", payload.iss, options.issuer);
+    assertStringArrayContainsString(
+      JwtInvalidIssuerError,
+      "Issuer",
+      payload.iss,
+      options.issuer
+    );
   }
 
   // Check audience
@@ -199,12 +209,18 @@ export function validateJwtFields(
         "audience must be provided or set to null explicitly"
       );
     }
-    assertStringArraysOverlap("Audience", payload.aud, options.audience);
+    assertStringArraysOverlap(
+      JwtInvalidAudienceError,
+      "Audience",
+      payload.aud,
+      options.audience
+    );
   }
 
   // Check scope
   if (options.scope != null) {
     assertStringArraysOverlap(
+      JwtInvalidScopeError,
       "Scope",
       payload.scope?.split(" "),
       options.scope

--- a/tests/import-tests/commonjs.cjs
+++ b/tests/import-tests/commonjs.cjs
@@ -9,6 +9,7 @@ require("aws-jwt-verify/jwt-model");
 require("aws-jwt-verify/jwt-rsa");
 require("aws-jwt-verify/jwt");
 require("aws-jwt-verify/safe-json-parse");
+const { JwtInvalidIssuerError } = require("aws-jwt-verify/error");
 
 JwtRsaVerifier.create({
   jwksUri: "https://example.com/keys/jwks.json",
@@ -24,5 +25,11 @@ if (typeof https.fetchJson !== "function") {
   process.exit(1);
 }
 
-assertStringEquals("test foo", "foo", "foo");
+assertStringEquals(
+  JwtInvalidIssuerError,
+  "test foo",
+  "payload.iss",
+  "foo",
+  "foo"
+);
 console.log("CommonJS import succeeded!");

--- a/tests/import-tests/commonjs.cjs
+++ b/tests/import-tests/commonjs.cjs
@@ -25,11 +25,5 @@ if (typeof https.fetchJson !== "function") {
   process.exit(1);
 }
 
-assertStringEquals(
-  JwtInvalidIssuerError,
-  "test foo",
-  "payload.iss",
-  "foo",
-  "foo"
-);
+assertStringEquals("test foo", "foo", "foo", JwtInvalidIssuerError);
 console.log("CommonJS import succeeded!");

--- a/tests/import-tests/esm.mjs
+++ b/tests/import-tests/esm.mjs
@@ -25,11 +25,5 @@ if (typeof https.fetchJson !== "function") {
   process.exit(1);
 }
 
-assertStringEquals(
-  JwtInvalidIssuerError,
-  "test foo",
-  "payload.iss",
-  "foo",
-  "foo"
-);
+assertStringEquals("test foo", "foo", "foo", JwtInvalidIssuerError);
 console.log("ESM import succeeded!");

--- a/tests/import-tests/esm.mjs
+++ b/tests/import-tests/esm.mjs
@@ -9,6 +9,7 @@ import {} from "aws-jwt-verify/jwt-model";
 import {} from "aws-jwt-verify/jwt-rsa";
 import {} from "aws-jwt-verify/jwt";
 import {} from "aws-jwt-verify/safe-json-parse";
+import { JwtInvalidIssuerError } from "aws-jwt-verify/error";
 
 JwtRsaVerifier.create({
   jwksUri: "https://example.com/keys/jwks.json",
@@ -24,5 +25,11 @@ if (typeof https.fetchJson !== "function") {
   process.exit(1);
 }
 
-assertStringEquals("test foo", "foo", "foo");
+assertStringEquals(
+  JwtInvalidIssuerError,
+  "test foo",
+  "payload.iss",
+  "foo",
+  "foo"
+);
 console.log("ESM import succeeded!");

--- a/tests/import-tests/typescript.ts
+++ b/tests/import-tests/typescript.ts
@@ -9,6 +9,7 @@ import {} from "aws-jwt-verify/jwt-model";
 import {} from "aws-jwt-verify/jwt-rsa";
 import {} from "aws-jwt-verify/jwt";
 import {} from "aws-jwt-verify/safe-json-parse";
+import { JwtInvalidIssuerError } from "aws-jwt-verify/error";
 
 JwtRsaVerifier.create({
   jwksUri: "https://example.com/keys/jwks.json",
@@ -24,5 +25,11 @@ if (typeof https.fetchJson !== "function") {
   process.exit(1);
 }
 
-assertStringEquals("test foo", "foo", "foo");
+assertStringEquals(
+  JwtInvalidIssuerError,
+  "test foo",
+  "payload.iss",
+  "foo",
+  "foo"
+);
 console.log("TypeScript import succeeded!");

--- a/tests/import-tests/typescript.ts
+++ b/tests/import-tests/typescript.ts
@@ -25,11 +25,5 @@ if (typeof https.fetchJson !== "function") {
   process.exit(1);
 }
 
-assertStringEquals(
-  JwtInvalidIssuerError,
-  "test foo",
-  "payload.iss",
-  "foo",
-  "foo"
-);
+assertStringEquals("test foo", "foo", "foo", JwtInvalidIssuerError);
 console.log("TypeScript import succeeded!");

--- a/tests/unit/assert.test.ts
+++ b/tests/unit/assert.test.ts
@@ -1,45 +1,69 @@
+import { FailedAssertionError, AssertedClaim } from "../../src/error";
 import {
   assertStringEquals,
   assertStringArrayContainsString,
   assertStringArraysOverlap,
 } from "../../src/assert";
 
-class AssertionError extends Error {}
+class AssertionError extends FailedAssertionError {}
+const assertedClaim = "test" as AssertedClaim;
 
 describe("unit tests assert", () => {
   test("assert equals requires non-empty value", () => {
     const statement = () =>
-      assertStringEquals(AssertionError, "test", "", "two");
+      assertStringEquals(AssertionError, "test", assertedClaim, "", "two");
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("Missing test. Expected: two");
   });
 
   test("assert equals requires strings", () => {
     const statement = () =>
-      assertStringEquals(AssertionError, "test", 123 as any, "two");
+      assertStringEquals(
+        AssertionError,
+        "test",
+        assertedClaim,
+        123 as any,
+        "two"
+      );
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("test is not of type string");
   });
 
   test("assert contains requires strings", () => {
     const statement = () =>
-      assertStringArrayContainsString(AssertionError, "test", 123 as any, [
-        "two",
-      ]);
+      assertStringArrayContainsString(
+        AssertionError,
+        "test",
+        assertedClaim,
+        123 as any,
+        ["two"]
+      );
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("test is not of type string");
   });
 
   test("assert overlaps requires array", () => {
     const statement = () =>
-      assertStringArraysOverlap(AssertionError, "test", 123 as any, ["two"]);
+      assertStringArraysOverlap(
+        AssertionError,
+        "test",
+        assertedClaim,
+        123 as any,
+        ["two"]
+      );
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("test is not an array");
   });
 
   test("assert overlaps requires array of strings", () => {
     const statement = () =>
-      assertStringArraysOverlap(AssertionError, "test", [123 as any], ["two"]);
+      assertStringArraysOverlap(
+        AssertionError,
+        "test",
+        assertedClaim,
+        [123 as any],
+        ["two"]
+      );
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow(
       "test includes elements that are not of type string"

--- a/tests/unit/assert.test.ts
+++ b/tests/unit/assert.test.ts
@@ -3,38 +3,43 @@ import {
   assertStringArrayContainsString,
   assertStringArraysOverlap,
 } from "../../src/assert";
-import { AssertionError } from "../../src/error";
+
+class AssertionError extends Error {}
 
 describe("unit tests assert", () => {
   test("assert equals requires non-empty value", () => {
-    const statement = () => assertStringEquals("test", "", "two");
+    const statement = () =>
+      assertStringEquals(AssertionError, "test", "", "two");
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("Missing test. Expected: two");
   });
 
   test("assert equals requires strings", () => {
-    const statement = () => assertStringEquals("test", 123 as any, "two");
+    const statement = () =>
+      assertStringEquals(AssertionError, "test", 123 as any, "two");
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("test is not of type string");
   });
 
   test("assert contains requires strings", () => {
     const statement = () =>
-      assertStringArrayContainsString("test", 123 as any, ["two"]);
+      assertStringArrayContainsString(AssertionError, "test", 123 as any, [
+        "two",
+      ]);
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("test is not of type string");
   });
 
   test("assert overlaps requires array", () => {
     const statement = () =>
-      assertStringArraysOverlap("test", 123 as any, ["two"]);
+      assertStringArraysOverlap(AssertionError, "test", 123 as any, ["two"]);
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow("test is not an array");
   });
 
   test("assert overlaps requires array of strings", () => {
     const statement = () =>
-      assertStringArraysOverlap("test", [123 as any], ["two"]);
+      assertStringArraysOverlap(AssertionError, "test", [123 as any], ["two"]);
     expect(statement).toThrow(AssertionError);
     expect(statement).toThrow(
       "test includes elements that are not of type string"

--- a/tests/unit/assert.test.ts
+++ b/tests/unit/assert.test.ts
@@ -1,72 +1,88 @@
-import { FailedAssertionError, AssertedClaim } from "../../src/error";
+import { FailedAssertionError } from "../../src/error";
 import {
   assertStringEquals,
   assertStringArrayContainsString,
   assertStringArraysOverlap,
 } from "../../src/assert";
 
-class AssertionError extends FailedAssertionError {}
-const assertedClaim = "test" as AssertedClaim;
+class CustomError extends FailedAssertionError {}
 
 describe("unit tests assert", () => {
   test("assert equals requires non-empty value", () => {
-    const statement = () =>
-      assertStringEquals(AssertionError, "test", assertedClaim, "", "two");
-    expect(statement).toThrow(AssertionError);
-    expect(statement).toThrow("Missing test. Expected: two");
+    const actual = "";
+    const expected = "two";
+    const statement = () => assertStringEquals("Test", actual, expected);
+    expect.assertions(3);
+    expect(statement).toThrow(FailedAssertionError);
+    expect(statement).toThrow("Missing Test. Expected: two");
+    try {
+      statement();
+    } catch (err) {
+      if (err instanceof FailedAssertionError) {
+        expect(err.failedAssertion).toMatchObject({
+          actual,
+          expected,
+        });
+      }
+    }
   });
 
   test("assert equals requires strings", () => {
+    const actual = 123 as any;
+    const expected = "two";
     const statement = () =>
-      assertStringEquals(
-        AssertionError,
-        "test",
-        assertedClaim,
-        123 as any,
-        "two"
-      );
-    expect(statement).toThrow(AssertionError);
-    expect(statement).toThrow("test is not of type string");
+      assertStringEquals("Test", actual, expected, CustomError);
+    expect.assertions(3);
+    expect(statement).toThrow(CustomError);
+    expect(statement).toThrow("Test is not of type string");
+    try {
+      statement();
+    } catch (err) {
+      if (err instanceof CustomError) {
+        expect(err.failedAssertion).toMatchObject({
+          actual,
+          expected,
+        });
+      }
+    }
   });
 
   test("assert contains requires strings", () => {
     const statement = () =>
-      assertStringArrayContainsString(
-        AssertionError,
-        "test",
-        assertedClaim,
-        123 as any,
-        ["two"]
-      );
-    expect(statement).toThrow(AssertionError);
-    expect(statement).toThrow("test is not of type string");
+      assertStringArrayContainsString("Test", 123 as any, ["two"], CustomError);
+    expect(statement).toThrow(CustomError);
+    expect(statement).toThrow("Test is not of type string");
+  });
+
+  test("assert contains requires strings - with default error", () => {
+    const statement = () =>
+      assertStringArrayContainsString("Test", 123 as any, ["two"]);
+    expect(statement).toThrow(FailedAssertionError);
+    expect(statement).toThrow("Test is not of type string");
   });
 
   test("assert overlaps requires array", () => {
     const statement = () =>
-      assertStringArraysOverlap(
-        AssertionError,
-        "test",
-        assertedClaim,
-        123 as any,
-        ["two"]
-      );
-    expect(statement).toThrow(AssertionError);
-    expect(statement).toThrow("test is not an array");
+      assertStringArraysOverlap("Test", 123 as any, ["two"], CustomError);
+    expect(statement).toThrow(CustomError);
+    expect(statement).toThrow("Test is not an array");
   });
 
   test("assert overlaps requires array of strings", () => {
     const statement = () =>
-      assertStringArraysOverlap(
-        AssertionError,
-        "test",
-        assertedClaim,
-        [123 as any],
-        ["two"]
-      );
-    expect(statement).toThrow(AssertionError);
+      assertStringArraysOverlap("Test", [123 as any], ["two"], CustomError);
+    expect(statement).toThrow(CustomError);
     expect(statement).toThrow(
-      "test includes elements that are not of type string"
+      "Test includes elements that are not of type string"
+    );
+  });
+
+  test("assert overlaps requires array of strings - with default error", () => {
+    const statement = () =>
+      assertStringArraysOverlap("Test", [123 as any], ["two"]);
+    expect(statement).toThrow(FailedAssertionError);
+    expect(statement).toThrow(
+      "Test includes elements that are not of type string"
     );
   });
 });

--- a/tests/unit/cognito-verifier.test.ts
+++ b/tests/unit/cognito-verifier.test.ts
@@ -7,7 +7,11 @@ import {
 import { decomposeJwt } from "../../src/jwt";
 import { JwksCache, Jwks } from "../../src/jwk";
 import { CognitoJwtVerifier } from "../../src/cognito-verifier";
-import { AssertionError, ParameterValidationError } from "../../src/error";
+import {
+  ParameterValidationError,
+  CognitoJwtInvalidTokenUseError,
+  CognitoJwtInvalidGroupError,
+} from "../../src/error";
 
 describe("unit tests cognito verifier", () => {
   let keypair: ReturnType<typeof generateKeyPair>;
@@ -103,7 +107,7 @@ describe("unit tests cognito verifier", () => {
         });
         expect(() =>
           verifier.verifySync(signedIdJwt, { tokenUse: "access" })
-        ).toThrow(AssertionError);
+        ).toThrow(CognitoJwtInvalidTokenUseError);
       });
       test("access token check", () => {
         const verifier = CognitoJwtVerifier.create({
@@ -128,7 +132,7 @@ describe("unit tests cognito verifier", () => {
         });
         expect(() =>
           verifier.verifySync(signedAccessJwt, { tokenUse: "id" })
-        ).toThrow(AssertionError);
+        ).toThrow(CognitoJwtInvalidTokenUseError);
       });
       test("missing token use", () => {
         const verifier = CognitoJwtVerifier.create({
@@ -150,7 +154,7 @@ describe("unit tests cognito verifier", () => {
           "Missing Token use. Expected one of: id, access"
         );
         expect(() => verifier.verifySync(signedAccessJwt)).toThrow(
-          AssertionError
+          CognitoJwtInvalidTokenUseError
         );
       });
       test("Cognito group check works", () => {
@@ -197,14 +201,18 @@ describe("unit tests cognito verifier", () => {
           token_use: "access",
           hello: "world",
         });
-        expect(() => verifier.verifySync(userJwt)).toThrow(AssertionError);
+        expect(() => verifier.verifySync(userJwt)).toThrow(
+          CognitoJwtInvalidGroupError
+        );
         expect(
           verifier.verifySync(userJwt, { groups: ["users"] })
         ).toMatchObject({
           token_use: "access",
           hello: "world",
         });
-        expect(() => verifier.verifySync(noGroupJwt)).toThrow(AssertionError);
+        expect(() => verifier.verifySync(noGroupJwt)).toThrow(
+          CognitoJwtInvalidGroupError
+        );
       });
       test("clientId undefined", () => {
         const verifier = CognitoJwtVerifier.create({

--- a/tests/unit/cognito-verifier.test.ts
+++ b/tests/unit/cognito-verifier.test.ts
@@ -11,6 +11,7 @@ import {
   ParameterValidationError,
   CognitoJwtInvalidTokenUseError,
   CognitoJwtInvalidGroupError,
+  JwtInvalidClaimError,
 } from "../../src/error";
 
 describe("unit tests cognito verifier", () => {
@@ -58,6 +59,149 @@ describe("unit tests cognito verifier", () => {
           payload: decomposedJwt.payload,
           jwk: keypair.jwk,
         });
+      });
+    });
+    describe("includeRawJwtInErrors", () => {
+      test("verify - flag set at statement level", () => {
+        const userPoolId = "us-east-1_123456";
+        const { issuer } = CognitoJwtVerifier.parseUserPoolId(userPoolId);
+        const header = { alg: "RS256", kid: keypair.jwk.kid };
+        const payload = {
+          hello: "world",
+          iss: issuer,
+          token_use: "access",
+        };
+        const signedJwt = signJwt(header, payload, keypair.privateKey);
+        const cognitoVerifier = CognitoJwtVerifier.create({
+          userPoolId,
+        });
+        cognitoVerifier.cacheJwks(keypair.jwks);
+        const statement = () =>
+          cognitoVerifier.verify(signedJwt, {
+            clientId: null,
+            tokenUse: "id",
+            includeRawJwtInErrors: true,
+          });
+        expect.assertions(2);
+        expect(statement).rejects.toThrow(CognitoJwtInvalidTokenUseError);
+        return statement().catch((err) => {
+          expect((err as JwtInvalidClaimError).rawJwt).toMatchObject({
+            header,
+            payload,
+          });
+        });
+      });
+      test("verify - flag set at verifier level", () => {
+        const userPoolId = "us-east-1_123456";
+        const { issuer } = CognitoJwtVerifier.parseUserPoolId(userPoolId);
+        const header = { alg: "RS256", kid: keypair.jwk.kid };
+        const payload = {
+          hello: "world",
+          iss: issuer,
+          token_use: "access",
+        };
+        const signedJwt = signJwt(header, payload, keypair.privateKey);
+        const cognitoVerifier = CognitoJwtVerifier.create({
+          userPoolId,
+          includeRawJwtInErrors: true,
+        });
+        cognitoVerifier.cacheJwks(keypair.jwks);
+        const statement = () =>
+          cognitoVerifier.verify(signedJwt, {
+            clientId: null,
+            tokenUse: "id",
+          });
+        expect.assertions(2);
+        expect(statement).rejects.toThrow(CognitoJwtInvalidTokenUseError);
+        return statement().catch((err) => {
+          expect((err as JwtInvalidClaimError).rawJwt).toMatchObject({
+            header,
+            payload,
+          });
+        });
+      });
+      test("verify - flag NOT set", () => {
+        const userPoolId = "us-east-1_123456";
+        const { issuer } = CognitoJwtVerifier.parseUserPoolId(userPoolId);
+        const header = { alg: "RS256", kid: keypair.jwk.kid };
+        const payload = {
+          hello: "world",
+          iss: issuer,
+          token_use: "access",
+        };
+        const signedJwt = signJwt(header, payload, keypair.privateKey);
+        const cognitoVerifier = CognitoJwtVerifier.create({
+          userPoolId,
+        });
+        cognitoVerifier.cacheJwks(keypair.jwks);
+        const statement = () =>
+          cognitoVerifier.verify(signedJwt, {
+            clientId: null,
+            tokenUse: "id",
+          });
+        expect.assertions(2);
+        expect(statement).rejects.toThrow(CognitoJwtInvalidTokenUseError);
+        return statement().catch((err) => {
+          expect((err as JwtInvalidClaimError).rawJwt).toBe(undefined);
+        });
+      });
+      test("verifySync - flag set at verifier level", () => {
+        const userPoolId = "us-east-1_123456";
+        const { issuer } = CognitoJwtVerifier.parseUserPoolId(userPoolId);
+        const header = { alg: "RS256", kid: keypair.jwk.kid };
+        const payload = {
+          hello: "world",
+          iss: issuer,
+          token_use: "access",
+        };
+        const signedJwt = signJwt(header, payload, keypair.privateKey);
+        const cognitoVerifier = CognitoJwtVerifier.create({
+          userPoolId,
+          includeRawJwtInErrors: true,
+        });
+        cognitoVerifier.cacheJwks(keypair.jwks);
+        const statement = () =>
+          cognitoVerifier.verifySync(signedJwt, {
+            clientId: null,
+            tokenUse: "id",
+          });
+        expect.assertions(2);
+        expect(statement).toThrow(CognitoJwtInvalidTokenUseError);
+        try {
+          statement();
+        } catch (err) {
+          expect((err as JwtInvalidClaimError).rawJwt).toMatchObject({
+            header,
+            payload,
+          });
+        }
+      });
+      test("verifySync - flag NOT set", () => {
+        const userPoolId = "us-east-1_123456";
+        const { issuer } = CognitoJwtVerifier.parseUserPoolId(userPoolId);
+        const header = { alg: "RS256", kid: keypair.jwk.kid };
+        const payload = {
+          hello: "world",
+          iss: issuer,
+          token_use: "access",
+        };
+        const signedJwt = signJwt(header, payload, keypair.privateKey);
+        const cognitoVerifier = CognitoJwtVerifier.create({
+          userPoolId,
+        });
+        cognitoVerifier.cacheJwks(keypair.jwks);
+        const statement = () =>
+          cognitoVerifier.verifySync(signedJwt, {
+            clientId: null,
+            tokenUse: "id",
+          });
+        expect.assertions(2);
+        expect(statement).toThrow(CognitoJwtInvalidTokenUseError);
+        try {
+          statement();
+        } catch (err) {
+          expect((err as JwtInvalidClaimError).rawJwt).toEqual(undefined);
+        }
       });
     });
     describe("verifySync", () => {

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -410,7 +410,7 @@ describe("unit tests jwt verifier", () => {
             audience: null,
             issuer: null,
           });
-        expect.assertions(4);
+        expect.assertions(3);
         expect(statement).toThrow(`Token expired at ${exp.toISOString()}`);
         expect(statement).toThrow(JwtExpiredError);
         try {
@@ -418,7 +418,6 @@ describe("unit tests jwt verifier", () => {
         } catch (err) {
           if (err instanceof JwtInvalidClaimError) {
             expect(err.failedAssertion.actual).toEqual(payload.exp);
-            expect(err.failedAssertion.claim).toEqual("payload.exp");
           }
         }
       });
@@ -507,7 +506,6 @@ describe("unit tests jwt verifier", () => {
         } catch (err) {
           if (err instanceof JwtInvalidClaimError) {
             expect(err.failedAssertion.actual).toEqual(nbf);
-            expect(err.failedAssertion.claim).toEqual("payload.nbf");
           }
         }
       });
@@ -596,7 +594,7 @@ describe("unit tests jwt verifier", () => {
         } catch (err) {
           if (err instanceof JwtInvalidClaimError) {
             expect(err.failedAssertion.actual).toEqual(["blah", "blah2"]);
-            expect(err.failedAssertion.claim).toEqual("payload.scope");
+            expect(err.failedAssertion.expected).toEqual("blah3");
           }
         }
       });


### PR DESCRIPTION
*Issue #, if available:* #24

*Description of changes:* Ability to include the raw JWT in thrown errors. Also, instead of a generic `AssertionError` more concrete errors are now thrown (e.g. `CognitoJwtInvalidGroupError`) to make it easier to recognize the concrete error at hand.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
