### PR TITLE
Remove test function from public interface declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,9 +588,6 @@ class CustomPenaltyBox implements PenaltyBox {
     // implement something better
     await new Promise((resolve) => setTimeout(resolve, 5000));
   }
-  public release(jwksUri: string, kid?: string) {
-    // implement
-  }
   public registerFailedAttempt(jwksUri: string, kid: string) {
     // implement
   }

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -140,7 +140,6 @@ export function isJwk(jwk: Json): jwk is Jwk {
 
 export interface PenaltyBox {
   wait: (jwksUri: string, kid: string) => Promise<void>;
-  release: (jwksUri: string, kid?: string) => void;
   registerFailedAttempt: (jwksUri: string, kid: string) => void;
   registerSuccessfulAttempt: (jwksUri: string, kid: string) => void;
 }

--- a/tests/unit/jwk.test.ts
+++ b/tests/unit/jwk.test.ts
@@ -195,7 +195,7 @@ describe("unit tests jwk", () => {
     }
     expect(error).toBeInstanceOf(KidNotFoundInJwksError);
     expect(fetcher.fetch).toHaveBeenCalledTimes(2);
-    jwksCache.penaltyBox.release(jwksUri);
+    penaltyBox.release(jwksUri);
   });
 
   describe("validate", () => {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Clean up: removes a test function (`release`) from the public interface


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
