### PR TITLE
Ensure rawJwt only includes header and payload, NOT signature

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { DecomposedJwt } from "./jwt.js";
+import { JwtHeader, JwtPayload } from "./jwt-model.js";
 
 /**
  * Base Error for all other errors in this file
@@ -63,13 +63,21 @@ export class JwtInvalidSignatureError extends JwtBaseError {}
 
 export class JwtInvalidSignatureAlgorithmError extends FailedAssertionError {}
 
+interface RawJwt {
+  header: JwtHeader;
+  payload: JwtPayload;
+}
+
 export abstract class JwtInvalidClaimError extends FailedAssertionError {
-  public rawJwt?: DecomposedJwt;
+  public rawJwt?: RawJwt;
   public withRawJwt<T extends JwtInvalidClaimError>(
     this: T,
-    rawJwt: DecomposedJwt
+    { header, payload }: RawJwt
   ): T {
-    this.rawJwt = rawJwt;
+    this.rawJwt = {
+      header,
+      payload,
+    };
     return this;
   }
 }

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -866,16 +866,16 @@ describe("unit tests jwt verifier", () => {
         expect.assertions(2);
         await expect(statement).rejects.toThrow(JwtExpiredError);
         return statement().catch((err) => {
-          expect((err as JwtInvalidClaimError).rawJwt).toMatchObject({
+          expect((err as JwtInvalidClaimError).rawJwt).toEqual({
             header,
             payload,
           });
         });
       });
       test("expired jwt and NOT includeRawJwtInErrors", async () => {
-        const exp = new Date();
+        const exp = Date.now() / 1000; // expires NOW
         const header = { alg: "RS256", kid: keypair.jwk.kid };
-        const payload = { hello: "world", exp: exp.valueOf() / 1000 };
+        const payload = { hello: "world", exp };
         const signedJwt = signJwt(header, payload, keypair.privateKey);
         const statement = () =>
           verifyJwt(
@@ -896,7 +896,8 @@ describe("unit tests jwt verifier", () => {
       test("included on custom errors too if subclassed from FailedAssertionError", async () => {
         class CustomError extends JwtInvalidClaimError {}
         const header = { alg: "RS256", kid: keypair.jwk.kid };
-        const payload = { hello: "world" };
+        const exp = Date.now() / 1000 + 10; // Expires in 10 secs
+        const payload = { hello: "world", exp };
         const signedJwt = signJwt(header, payload, keypair.privateKey);
         const statement = () =>
           verifyJwt(
@@ -917,7 +918,7 @@ describe("unit tests jwt verifier", () => {
         try {
           await statement();
         } catch (err) {
-          expect((err as CustomError).rawJwt).toMatchObject({
+          expect((err as CustomError).rawJwt).toEqual({
             header,
             payload,
           });


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Ensure rawJwt only includes header and payload, NOT signature


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
