### PR TITLE
Add exports of important types

### DIFF
--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -22,7 +22,7 @@ import {
 } from "./assert.js";
 import { Properties } from "./typing-util.js";
 
-interface CognitoVerifyProperties {
+export interface CognitoVerifyProperties {
   /**
    * The client ID that you expect to be present on the JWT
    * (In the ID token's aud claim, or the Access token's client_id claim).
@@ -78,7 +78,7 @@ interface CognitoVerifyProperties {
 }
 
 /** Type for Cognito JWT verifier properties, for a single User Pool */
-type CognitoJwtVerifierProperties = {
+export type CognitoJwtVerifierProperties = {
   /** The User Pool whose JWTs you want to verify */
   userPoolId: string;
 } & Partial<CognitoVerifyProperties>;
@@ -87,7 +87,7 @@ type CognitoJwtVerifierProperties = {
  * Type for Cognito JWT verifier properties, when multiple User Pools are used in the verifier.
  * In this case, you should be explicit in mapping `clientId` to User Pool.
  */
-type CognitoJwtVerifierMultiProperties = {
+export type CognitoJwtVerifierMultiProperties = {
   /** The User Pool whose JWTs you want to verify */
   userPoolId: string;
 } & CognitoVerifyProperties;
@@ -95,21 +95,22 @@ type CognitoJwtVerifierMultiProperties = {
 /**
  * Cognito JWT Verifier for a single user pool
  */
-type CognitoJwtVerifierSingleUserPool<T extends CognitoJwtVerifierProperties> =
-  CognitoJwtVerifier<
-    Properties<CognitoVerifyProperties, T>,
-    T &
-      JwtRsaVerifierProperties<CognitoVerifyProperties> & {
-        userPoolId: string;
-        audience: null;
-      },
-    false
-  >;
+export type CognitoJwtVerifierSingleUserPool<
+  T extends CognitoJwtVerifierProperties
+> = CognitoJwtVerifier<
+  Properties<CognitoVerifyProperties, T>,
+  T &
+    JwtRsaVerifierProperties<CognitoVerifyProperties> & {
+      userPoolId: string;
+      audience: null;
+    },
+  false
+>;
 
 /**
  * Cognito JWT Verifier for multiple user pools
  */
-type CognitoJwtVerifierMultiUserPool<
+export type CognitoJwtVerifierMultiUserPool<
   T extends CognitoJwtVerifierMultiProperties
 > = CognitoJwtVerifier<
   Properties<CognitoVerifyProperties, T>,

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -35,7 +35,7 @@ import {
 import { JsonObject } from "./safe-json-parse.js";
 
 /** Interface for JWT verification properties */
-interface VerifyProperties {
+export interface VerifyProperties {
   /**
    * The audience that you expect to be present in the JWT's aud claim.
    * If you provide a string array, that means at least one of those audiences
@@ -96,7 +96,7 @@ export type JwtRsaVerifierProperties<VerifyProps> = {
  * Type for JWT RSA verifier properties, when multiple issuers are used in the verifier.
  * In this case, you should be explicit in mapping audience to issuer.
  */
-type JwtRsaVerifierMultiProperties<T> = {
+export type JwtRsaVerifierMultiProperties<T> = {
   /**
    * URI where the JWKS (JSON Web Key Set) can be downloaded from.
    * The JWKS contains one or more JWKs, which represent the public keys with which
@@ -113,7 +113,7 @@ type JwtRsaVerifierMultiProperties<T> = {
 /**
  * JWT Verifier (RSA) for a single issuer
  */
-type JwtRsaVerifierSingleIssuer<
+export type JwtRsaVerifierSingleIssuer<
   T extends JwtRsaVerifierProperties<VerifyProperties>
 > = JwtRsaVerifier<
   Properties<VerifyProperties, T>,
@@ -137,7 +137,7 @@ type VerifyParameters<SpecificVerifyProperties> = {
 /**
  * JWT Verifier (RSA) for multiple issuers
  */
-type JwtRsaVerifierMultiIssuer<
+export type JwtRsaVerifierMultiIssuer<
   T extends JwtRsaVerifierMultiProperties<VerifyProperties>
 > = JwtRsaVerifier<
   Properties<VerifyProperties, T>,

--- a/tests/import-tests/typescript.ts
+++ b/tests/import-tests/typescript.ts
@@ -3,13 +3,21 @@ import * as awsJwtModule from "aws-jwt-verify";
 import * as https from "aws-jwt-verify/https";
 import { assertStringEquals } from "aws-jwt-verify/assert";
 import {} from "aws-jwt-verify/asn1";
-import {} from "aws-jwt-verify/cognito-verifier";
 import {} from "aws-jwt-verify/jwk";
 import {} from "aws-jwt-verify/jwt-model";
 import {} from "aws-jwt-verify/jwt-rsa";
 import {} from "aws-jwt-verify/jwt";
 import {} from "aws-jwt-verify/safe-json-parse";
 import { JwtInvalidIssuerError } from "aws-jwt-verify/error";
+import {
+  CognitoJwtVerifierMultiUserPool,
+  CognitoJwtVerifierSingleUserPool,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  CognitoVerifyProperties,
+  CognitoJwtVerifierMultiProperties,
+  CognitoJwtVerifierProperties,
+  CognitoJwtVerifier,
+} from "aws-jwt-verify/cognito-verifier";
 
 JwtRsaVerifier.create({
   jwksUri: "https://example.com/keys/jwks.json",
@@ -23,6 +31,54 @@ awsJwtModule.JwtRsaVerifier.create({
 
 if (typeof https.fetchJson !== "function") {
   process.exit(1);
+}
+
+let verifier: CognitoJwtVerifierSingleUserPool<{
+  userPoolId: string;
+  tokenUse: "id";
+}>;
+const verifyProps = {
+  tokenUse: "id" as const,
+};
+verifyProps as CognitoJwtVerifierProperties; // cast should work
+const verifierParams = {
+  userPoolId: "eu-west-1_abcdefgh",
+  ...verifyProps,
+};
+if (process.env.JUST_CHECKING_IF_THE_BELOW_TS_COMPILES_DONT_NEED_TO_RUN_IT) {
+  verifier = CognitoJwtVerifier.create(verifierParams);
+  verifier.verifySync("ey...", {
+    clientId: "abc",
+  });
+}
+
+if (process.env.JUST_CHECKING_IF_THE_BELOW_TS_COMPILES_DONT_NEED_TO_RUN_IT) {
+  const otherVerifier = CognitoJwtVerifier.create({
+    userPoolId: "",
+    clientId: "",
+  });
+  otherVerifier.verifySync("", {
+    tokenUse: "id",
+  });
+}
+
+let multiVerifier: CognitoJwtVerifierMultiUserPool<{
+  userPoolId: string;
+  tokenUse: "access";
+  clientId: string;
+}>;
+const multiVerifyProps = {
+  clientId: "xyz",
+  tokenUse: "access" as const,
+};
+multiVerifyProps as CognitoJwtVerifierMultiProperties; // cast should work
+const multiVerifierParams = {
+  userPoolId: "eu-west-1_abcdefgh",
+  ...multiVerifyProps,
+};
+if (process.env.JUST_CHECKING_IF_THE_BELOW_TS_COMPILES_DONT_NEED_TO_RUN_IT) {
+  multiVerifier = CognitoJwtVerifier.create(multiVerifierParams);
+  multiVerifier.verifySync("ey...");
 }
 
 assertStringEquals("test foo", "foo", "foo", JwtInvalidIssuerError);


### PR DESCRIPTION
*Issue #, if available:* #40

*Description of changes:* Add exports of important types, so users to define variables separately from the making the `CognitoJwtVerifier.create` call, as requested in #40. [Since changing these types would probably be breaking anyway, as they're return values, I see no reason to not export them and let users use them if they want.]

Usage as follows:

```typescript
import {
  CognitoJwtVerifierSingleUserPool,
  CognitoJwtVerifier, // Import this from the subnamespace now too, not from the top namespace (!)
} from "aws-jwt-verify/cognito-verifier";

// For the generic type parameter, provide the type of the object 
// that you will pass to the actual `create` call later:
let verifier: CognitoJwtVerifierSingleUserPool<{
  userPoolId: string;
  tokenUse: "id";
}>;

verifier = CognitoJwtVerifier.create({
  userPoolId: "<user pool id>",
  tokenUse: "id",
});
```

@elorzafe about your question. I'm slightly inclined to keep it like it is now: the type should be imported from the subnamespace `"aws-jwt-verify/cognito-verifier"`, not from `"aws-jwt-verify/cognito-verifier"`.

This keeps the top level namespace clean, which I like, and consider the type import above a bit more advanced, for which it would be okay to do the import from the subnamespace. The downside of this is, that it is harder to find that import. For me this tradeoff slightly favors cleanness of top level namespace. What do you think?

(Note there's multiple types/interfaces that would have to be available in top level namespace too. Would grow from 2 symbols to 10 symbols)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
