### PR TITLE
Harmonize type paths across CommonJS vs ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "dist/cjs/index.js",
   "type": "commonjs",
-  "types": "dist/cjs/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "files": [
     "dist",

--- a/tests/import-tests/typescript.ts
+++ b/tests/import-tests/typescript.ts
@@ -1,4 +1,4 @@
-import { JwtRsaVerifier } from "aws-jwt-verify";
+import { JwtRsaVerifier, CognitoJwtVerifier } from "aws-jwt-verify";
 import * as awsJwtModule from "aws-jwt-verify";
 import * as https from "aws-jwt-verify/https";
 import { assertStringEquals } from "aws-jwt-verify/assert";
@@ -12,11 +12,10 @@ import { JwtInvalidIssuerError } from "aws-jwt-verify/error";
 import {
   CognitoJwtVerifierMultiUserPool,
   CognitoJwtVerifierSingleUserPool,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  CognitoVerifyProperties,
+  CognitoVerifyProperties as _CognitoVerifyProperties,
   CognitoJwtVerifierMultiProperties,
   CognitoJwtVerifierProperties,
-  CognitoJwtVerifier,
+  CognitoJwtVerifier as _CognitoJwtVerifier,
 } from "aws-jwt-verify/cognito-verifier";
 
 JwtRsaVerifier.create({


### PR DESCRIPTION
*Issue #, if available:* #47

*Description of changes:* Use the same set of TypeScript types (from `dist/esm`) for top level (`aws-jwt-verify`) as for subpaths (e.g. `aws-jwt-verify/cognito-verifier`). This prevents TypeScript compile errors due to type mismatches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
