### PR TITLE
Only verify for the JWK at hand, that it is a JWK intended for RSA signatures

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -64,7 +64,6 @@ export function assertStringArrayContainsString<
   if (!actual) {
     throw new errorConstructor(
       `Missing ${name}. ${expectationMessage(expected)}`,
-
       actual,
       expected
     );
@@ -72,7 +71,6 @@ export function assertStringArrayContainsString<
   if (typeof actual !== "string") {
     throw new errorConstructor(
       `${name} is not of type string`,
-
       actual,
       expected
     );

--- a/src/error.ts
+++ b/src/error.ts
@@ -132,12 +132,6 @@ export class JwkInvalidUseError extends FailedAssertionError {}
 
 export class JwkInvalidKtyError extends FailedAssertionError {}
 
-export class JwkMissingModulusError extends FailedAssertionError {}
-
-export class JwkMissingExponentError extends FailedAssertionError {}
-
-export class JwkMissingKidError extends FailedAssertionError {}
-
 /**
  * HTTPS fetch errors
  */

--- a/src/error.ts
+++ b/src/error.ts
@@ -132,6 +132,12 @@ export class JwkInvalidUseError extends FailedAssertionError {}
 
 export class JwkInvalidKtyError extends FailedAssertionError {}
 
+export class JwkMissingModulusError extends FailedAssertionError {}
+
+export class JwkMissingExponentError extends FailedAssertionError {}
+
+export class JwkMissingKidError extends FailedAssertionError {}
+
 /**
  * HTTPS fetch errors
  */

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -55,7 +55,7 @@ export type JwkWithKid = Jwk & {
   kid: string;
 };
 
-function findJwkInJwks(jwks: Jwks, kid: string): JwkWithKid | undefined {
+export function findJwkInJwks(jwks: Jwks, kid: string): JwkWithKid | undefined {
   return jwks.keys.find(
     (jwk) => jwk.kid != null && jwk.kid === kid
   ) as JwkWithKid;

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -13,9 +13,6 @@ import {
   JwtWithoutValidKidError,
   JwkInvalidUseError,
   JwkInvalidKtyError,
-  JwkMissingExponentError,
-  JwkMissingModulusError,
-  JwkMissingKidError,
 } from "./error.js";
 import { nodeWebCompat } from "#node-web-compat";
 import { assertStringEquals } from "./assert.js";
@@ -120,14 +117,11 @@ export function assertIsRsaSignatureJwk(
   // Check JWK kty
   assertStringEquals("JWK kty", jwk.kty, "RSA", JwkInvalidKtyError);
 
-  // Check kid has a value
-  if (!jwk.kid) throw new JwkMissingKidError("Missing key id (kid)", jwk.kid);
-
   // Check modulus (n) has a value
-  if (!jwk.n) throw new JwkMissingModulusError("Missing modulus (n)", jwk.n);
+  if (!jwk.n) throw new JwkValidationError("Missing modulus (n)");
 
   // Check exponent (e) has a value
-  if (!jwk.e) throw new JwkMissingExponentError("Missing exponent (e)", jwk.e);
+  if (!jwk.e) throw new JwkValidationError("Missing exponent (e)");
 }
 
 export function assertIsJwk(jwk: Json): asserts jwk is Jwk {

--- a/src/jwt-rsa.ts
+++ b/src/jwt-rsa.ts
@@ -5,6 +5,7 @@ import {
   SimpleJwksCache,
   JwksCache,
   Jwk,
+  JwkWithKid,
   RsaSignatureJwk,
   Jwks,
   isJwk,
@@ -779,13 +780,17 @@ export class KeyObjectCache {
     jwk: RsaSignatureJwk,
     issuer?: Issuer
   ): GenericKeyObject {
-    if (!issuer) {
+    if (!issuer || !jwk.kid) {
       return this.transformJwkToKeyObjectSyncFn(jwk);
     }
     const fromCache = this.publicKeys.get(issuer)?.get(jwk.kid);
     if (fromCache) return fromCache;
     const publicKey = this.transformJwkToKeyObjectSyncFn(jwk);
-    this.putKeyObjectInCache(jwk, issuer, publicKey);
+    this.putKeyObjectInCache(
+      jwk as RsaSignatureJwk & JwkWithKid,
+      issuer,
+      publicKey
+    );
     return publicKey;
   }
 
@@ -793,18 +798,22 @@ export class KeyObjectCache {
     jwk: RsaSignatureJwk,
     issuer?: Issuer
   ): Promise<GenericKeyObject> {
-    if (!issuer) {
+    if (!issuer || !jwk.kid) {
       return this.transformJwkToKeyObjectAsyncFn(jwk);
     }
     const fromCache = this.publicKeys.get(issuer)?.get(jwk.kid);
     if (fromCache) return fromCache;
     const publicKey = await this.transformJwkToKeyObjectAsyncFn(jwk);
-    this.putKeyObjectInCache(jwk, issuer, publicKey);
+    this.putKeyObjectInCache(
+      jwk as RsaSignatureJwk & JwkWithKid,
+      issuer,
+      publicKey
+    );
     return publicKey;
   }
 
   private putKeyObjectInCache(
-    jwk: RsaSignatureJwk,
+    jwk: RsaSignatureJwk & JwkWithKid,
     issuer: string,
     publicKey: GenericKeyObject
   ) {

--- a/src/node-web-compat-node.ts
+++ b/src/node-web-compat-node.ts
@@ -4,7 +4,7 @@
 // Node.js implementations for the node-web-compatibility layer
 
 import { createPublicKey, createVerify, KeyObject } from "crypto";
-import { Jwk } from "./jwk.js";
+import { RsaSignatureJwk } from "./jwk.js";
 import { constructPublicKeyInDerFormat } from "./asn1.js";
 import { fetchJson } from "./https-node.js";
 import { NodeWebCompat } from "./node-web-compat.js";
@@ -20,7 +20,7 @@ enum JwtSignatureAlgorithms {
 
 export const nodeWebCompat: NodeWebCompat = {
   fetchJson,
-  transformJwkToKeyObjectSync: (jwk: Jwk) =>
+  transformJwkToKeyObjectSync: (jwk: RsaSignatureJwk) =>
     createPublicKey({
       key: constructPublicKeyInDerFormat(
         Buffer.from(jwk.n, "base64"),
@@ -29,7 +29,7 @@ export const nodeWebCompat: NodeWebCompat = {
       format: "der",
       type: "spki",
     }),
-  transformJwkToKeyObjectAsync: async (jwk: Jwk) =>
+  transformJwkToKeyObjectAsync: async (jwk: RsaSignatureJwk) =>
     createPublicKey({
       key: constructPublicKeyInDerFormat(
         Buffer.from(jwk.n, "base64"),

--- a/src/node-web-compat-web.ts
+++ b/src/node-web-compat-web.ts
@@ -3,7 +3,7 @@
 //
 // Web implementations for the node-web-compatibility layer
 
-import { Jwk } from "./jwk.js";
+import { RsaSignatureJwk } from "./jwk.js";
 import { FetchError, NotSupportedError } from "./error.js";
 import { NodeWebCompat } from "./node-web-compat.js";
 import { validateHttpsJsonResponse } from "./https-common.js";
@@ -56,7 +56,7 @@ export const nodeWebCompat: NodeWebCompat = {
       "Synchronously transforming a JWK into a key object is not supported in the browser"
     );
   },
-  transformJwkToKeyObjectAsync: (jwk: Jwk) =>
+  transformJwkToKeyObjectAsync: (jwk: RsaSignatureJwk) =>
     window.crypto.subtle.importKey(
       "jwk",
       jwk,

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -10,9 +10,7 @@ import {
 import { decomposeJwt } from "../../src/jwt";
 import {
   JwkInvalidUseError,
-  JwkMissingModulusError,
-  JwkMissingExponentError,
-  JwkMissingKidError,
+  JwkValidationError,
   JwtExpiredError,
   JwtInvalidAudienceError,
   JwtInvalidClaimError,
@@ -857,18 +855,6 @@ describe("unit tests jwt verifier", () => {
         expect(statement).toThrow("Missing JWK use. Expected: sig");
         expect(statement).toThrow(JwkInvalidUseError);
       });
-      test("missing kid on JWK", () => {
-        const { jwk, privateKey } = generateKeyPair();
-        const signedJwt = signJwt({}, {}, privateKey);
-        delete (jwk as Jwk).kid;
-        const statement = () =>
-          verifyJwtSync(signedJwt, jwk, {
-            audience: null,
-            issuer: null,
-          });
-        expect(statement).toThrow("Missing key id (kid)");
-        expect(statement).toThrow(JwkMissingKidError);
-      });
       test("missing modulus on JWK", () => {
         const { jwk, privateKey } = generateKeyPair();
         const signedJwt = signJwt({}, {}, privateKey);
@@ -879,7 +865,7 @@ describe("unit tests jwt verifier", () => {
             issuer: null,
           });
         expect(statement).toThrow("Missing modulus (n)");
-        expect(statement).toThrow(JwkMissingModulusError);
+        expect(statement).toThrow(JwkValidationError);
       });
       test("missing exponent on JWK", () => {
         const { jwk, privateKey } = generateKeyPair();
@@ -891,7 +877,7 @@ describe("unit tests jwt verifier", () => {
             issuer: null,
           });
         expect(statement).toThrow("Missing exponent (e)");
-        expect(statement).toThrow(JwkMissingExponentError);
+        expect(statement).toThrow(JwkValidationError);
       });
     });
     describe("includeJwtInErrors", () => {

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -1575,19 +1575,49 @@ describe("unit tests jwt verifier", () => {
       pubkeyCache.transformJwkToKeyObjectSync(otherJwk, "testissuer"); // Cache is empty, so must be regenerated
       expect(jwkToKeyObjectTransformerSpy).toHaveBeenCalledTimes(5);
     });
-    test("no issuer and kid", () => {
+    test("no issuer", () => {
+      const issuer = undefined;
       const pubkeyCache = new KeyObjectCache();
       const pubkey = pubkeyCache.transformJwkToKeyObjectSync(
-        keypair.jwk as RsaSignatureJwk
+        keypair.jwk as RsaSignatureJwk,
+        issuer
       ) as KeyObject;
       expect(pubkey.export({ format: "der", type: "spki" })).toEqual(
         keypair.publicKeyDer
       );
     });
-    test("no issuer and kid - async", async () => {
+    test("no issuer - async", async () => {
+      const issuer = undefined;
       const pubkeyCache = new KeyObjectCache();
       const pubkey = (await pubkeyCache.transformJwkToKeyObjectAsync(
-        keypair.jwk as RsaSignatureJwk
+        keypair.jwk as RsaSignatureJwk,
+        issuer
+      )) as KeyObject;
+      expect(pubkey.export({ format: "der", type: "spki" })).toEqual(
+        keypair.publicKeyDer
+      );
+    });
+    test("no kid", () => {
+      const issuer = "testissuer";
+      const pubkeyCache = new KeyObjectCache();
+      const jwk = { ...keypair.jwk } as RsaSignatureJwk;
+      delete jwk.kid;
+      const pubkey = pubkeyCache.transformJwkToKeyObjectSync(
+        jwk,
+        issuer
+      ) as KeyObject;
+      expect(pubkey.export({ format: "der", type: "spki" })).toEqual(
+        keypair.publicKeyDer
+      );
+    });
+    test("no kid - async", async () => {
+      const issuer = "testissuer";
+      const pubkeyCache = new KeyObjectCache();
+      const jwk = { ...keypair.jwk } as RsaSignatureJwk;
+      delete jwk.kid;
+      const pubkey = (await pubkeyCache.transformJwkToKeyObjectAsync(
+        jwk,
+        issuer
       )) as KeyObject;
       expect(pubkey.export({ format: "der", type: "spki" })).toEqual(
         keypair.publicKeyDer

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -101,6 +101,35 @@ describe("unit tests jwt verifier", () => {
           verifyJwtSync(signedJwt, keypair.jwks, { issuer, audience })
         ).toMatchObject({ hello: "world" });
       });
+      test("happy flow with mixed JWKS - JWKS that includes non-RSA keys", () => {
+        const issuer = "https://example.com";
+        const audience = "1234";
+        const signedJwt = signJwt(
+          { kid: keypair.jwk.kid },
+          { aud: audience, iss: issuer, hello: "world" },
+          keypair.privateKey
+        );
+        const mixedJwks: Jwks = {
+          keys: [
+            {
+              kty: "EC",
+              alg: "ES256",
+              use: "sig",
+              kid: "somekid",
+            },
+            keypair.jwk,
+            {
+              kty: "EC",
+              alg: "ES256",
+              use: "sig",
+              hasNoKid: "test",
+            },
+          ],
+        };
+        expect(
+          verifyJwtSync(signedJwt, mixedJwks, { issuer, audience })
+        ).toMatchObject({ hello: "world" });
+      });
       test("happy flow JWT with multiple audience values", () => {
         const issuer = "https://example.com";
         const audience = ["1234", "5678"];

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -881,6 +881,18 @@ describe("unit tests jwt verifier", () => {
         );
         expect(statement).toThrow(JwkInvalidUseError);
       });
+      test("missing JWK use", () => {
+        const { jwk, privateKey } = generateKeyPair();
+        const signedJwt = signJwt({}, {}, privateKey);
+        delete (jwk as Jwk).use;
+        const statement = () =>
+          verifyJwtSync(signedJwt, jwk, {
+            audience: null,
+            issuer: null,
+          });
+        expect(statement).toThrow("Missing JWK use. Expected: sig");
+        expect(statement).toThrow(JwkInvalidUseError);
+      });
     });
     describe("includeJwtInErrors", () => {
       test("expired jwt with flag set", () => {

--- a/tests/unit/jwt-rsa.test.ts
+++ b/tests/unit/jwt-rsa.test.ts
@@ -284,42 +284,6 @@ describe("unit tests jwt verifier", () => {
         expect(statement).toThrow("Missing Issuer. Expected: expectedIssuer");
         expect(statement).toThrow(JwtInvalidIssuerError);
       });
-      test("missing kid on JWK", () => {
-        const signedJwt = signJwt({}, {}, keypair.privateKey);
-        const { jwk } = generateKeyPair();
-        delete (jwk as Jwk).kid;
-        const statement = () =>
-          verifyJwtSync(signedJwt, jwk, {
-            audience: null,
-            issuer: null,
-          });
-        expect(statement).toThrow("Missing key id (kid)");
-        expect(statement).toThrow(JwkMissingKidError);
-      });
-      test("missing modulus on JWK", () => {
-        const signedJwt = signJwt({}, {}, keypair.privateKey);
-        const { jwk } = generateKeyPair();
-        delete (jwk as Jwk).n;
-        const statement = () =>
-          verifyJwtSync(signedJwt, jwk, {
-            audience: null,
-            issuer: null,
-          });
-        expect(statement).toThrow("Missing modulus (n)");
-        expect(statement).toThrow(JwkMissingModulusError);
-      });
-      test("missing exponent on JWK", () => {
-        const signedJwt = signJwt({}, {}, keypair.privateKey);
-        const { jwk } = generateKeyPair();
-        delete (jwk as Jwk).e;
-        const statement = () =>
-          verifyJwtSync(signedJwt, jwk, {
-            audience: null,
-            issuer: null,
-          });
-        expect(statement).toThrow("Missing exponent (e)");
-        expect(statement).toThrow(JwkMissingExponentError);
-      });
     });
 
     describe("parse errors", () => {
@@ -892,6 +856,42 @@ describe("unit tests jwt verifier", () => {
           });
         expect(statement).toThrow("Missing JWK use. Expected: sig");
         expect(statement).toThrow(JwkInvalidUseError);
+      });
+      test("missing kid on JWK", () => {
+        const { jwk, privateKey } = generateKeyPair();
+        const signedJwt = signJwt({}, {}, privateKey);
+        delete (jwk as Jwk).kid;
+        const statement = () =>
+          verifyJwtSync(signedJwt, jwk, {
+            audience: null,
+            issuer: null,
+          });
+        expect(statement).toThrow("Missing key id (kid)");
+        expect(statement).toThrow(JwkMissingKidError);
+      });
+      test("missing modulus on JWK", () => {
+        const { jwk, privateKey } = generateKeyPair();
+        const signedJwt = signJwt({}, {}, privateKey);
+        delete (jwk as Jwk).n;
+        const statement = () =>
+          verifyJwtSync(signedJwt, jwk, {
+            audience: null,
+            issuer: null,
+          });
+        expect(statement).toThrow("Missing modulus (n)");
+        expect(statement).toThrow(JwkMissingModulusError);
+      });
+      test("missing exponent on JWK", () => {
+        const { jwk, privateKey } = generateKeyPair();
+        const signedJwt = signJwt({}, {}, privateKey);
+        delete (jwk as Jwk).e;
+        const statement = () =>
+          verifyJwtSync(signedJwt, jwk, {
+            audience: null,
+            issuer: null,
+          });
+        expect(statement).toThrow("Missing exponent (e)");
+        expect(statement).toThrow(JwkMissingExponentError);
       });
     });
     describe("includeJwtInErrors", () => {


### PR DESCRIPTION
*Issue #, if available:* #68

*Description of changes:* Only verify for the JWK at hand, that it is a JWK intended for RSA signatures.

In other words: the complete JWKS may from this change onwards, also comprise non-RSA JWKs (e.g. for elliptic curve signatures). Previously, the inclusion of a non-RSA JWK in the JWKS would throw an error, even if that JWK was not used for the signature verification of the JWT at hand.

So the following (new) unit test now passes, where it would have failed before––because there's non-RSA JWKs in the JWKS, that triggered a JWK validation failure before:

https://github.com/awslabs/aws-jwt-verify/blob/752212b283fa395b6076569f59253f9fbab2d90c/tests/unit/jwt-rsa.test.ts#L104-L132


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
