### PR TITLE
Remove references to window

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,13 @@ module.exports = {
       "warn",
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
     ],
+    "no-restricted-globals": [
+      "error",
+      {
+        name: "window",
+        message:
+          "Don't use the window global, as you don't need to use it and it's not a defined global in the Next.js Edge Runtime",
+      },
+    ],
   },
 };

--- a/src/node-web-compat-web.ts
+++ b/src/node-web-compat-web.ts
@@ -68,7 +68,7 @@ export const nodeWebCompat: NodeWebCompat = {
         alg
       );
     }
-    return window.crypto.subtle.importKey(
+    return crypto.subtle.importKey(
       "jwk",
       jwk,
       {
@@ -86,7 +86,7 @@ export const nodeWebCompat: NodeWebCompat = {
     );
   },
   verifySignatureAsync: ({ jwsSigningInput, keyObject, signature }) =>
-    window.crypto.subtle.verify(
+    crypto.subtle.verify(
       {
         name: "RSASSA-PKCS1-v1_5",
       },
@@ -96,7 +96,7 @@ export const nodeWebCompat: NodeWebCompat = {
     ),
   parseB64UrlString: (b64: string): string =>
     new TextDecoder().decode(bufferFromBase64url(b64)),
-  setTimeoutUnref: window.setTimeout.bind(window),
+  setTimeoutUnref: setTimeout.bind(undefined),
 };
 
 const bufferFromBase64url = (function () {


### PR DESCRIPTION
- Remove references to window in node-web-compat-web.ts This is a fix for the next.js edge runtime

*Issue #, if available:*
108

*Description of changes:*
As suggested in the issue thread, references to `window` were removed. `window.setTimeout.bind(window)` was replaced with `setTimeout.bind(undefined)`. This fixed the errors that were previously experienced. 
I suggest to add one or more tests that cover support for next.js edge runtime, since this package is an amazing fit for middleware.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
