### PR TITLE
fix: pin build to npm v9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: "14"
       - name: install
         run: |
-          npm install -g npm
+          npm install -g npm@9
           npm install
       - name: test
         run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- last PRs are failing on CI build due to npm@latest not compatible with node 14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
