### PR TITLE
Fix MSB 1 leading to negative modulus in bun

### DIFF
--- a/src/asn1.ts
+++ b/src/asn1.ts
@@ -68,10 +68,10 @@ function encodeLength(length: number) {
 }
 
 /**
- * Encode a buffer (that represent a positive integer) as integer per ASN.1 spec (DER-encoding)
+ * Encode a buffer (that represents a positive integer) as integer per ASN.1 spec (DER-encoding)
  * See https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf chapter 8.3
  *
- * @param buffer - The buffer that represent an integer to encode
+ * @param buffer - The buffer that represents a positive integer
  * @returns The buffer
  */
 function encodeBufferAsPositiveInteger(buffer: Buffer) {

--- a/src/asn1.ts
+++ b/src/asn1.ts
@@ -68,13 +68,17 @@ function encodeLength(length: number) {
 }
 
 /**
- * Encode a buffer (that represent an integer) as integer per ASN.1 spec (DER-encoding)
+ * Encode a buffer (that represent a positive integer) as integer per ASN.1 spec (DER-encoding)
  * See https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf chapter 8.3
  *
  * @param buffer - The buffer that represent an integer to encode
  * @returns The buffer
  */
-function encodeBufferAsInteger(buffer: Buffer) {
+function encodeBufferAsPositiveInteger(buffer: Buffer) {
+  if (buffer[0] >> 7) {
+    // MSB is 1, add leading zero to indicate positive number
+    buffer = Buffer.concat([Buffer.from([0]), buffer]);
+  }
   return Buffer.concat([
     encodeIdentifier({
       class: Asn1Class.Universal,
@@ -213,7 +217,10 @@ export function constructPublicKeyInDerFormat(n: Buffer, e: Buffer): Buffer {
   return encodeSequence([
     ALGORITHM_RSA_ENCRYPTION,
     encodeBufferAsBitString(
-      encodeSequence([encodeBufferAsInteger(n), encodeBufferAsInteger(e)])
+      encodeSequence([
+        encodeBufferAsPositiveInteger(n),
+        encodeBufferAsPositiveInteger(e),
+      ])
     ),
   ]);
 }

--- a/tests/unit/asn1.test.ts
+++ b/tests/unit/asn1.test.ts
@@ -30,6 +30,45 @@ describe("unit tests asn1", () => {
     expect(publicKey).toEqual(priorGeneratedPublicKey);
   });
 
+  test("Prepends 0 byte only if MSB is 1", () => {
+    const n = Buffer.from([0b10000000]); // MSB 1
+    const e = Buffer.from([0b01000000]); // MSB 0
+    const publicKeyDer = constructPublicKeyInDerFormat(n, e);
+    expect(publicKeyDer).toEqual(
+      Buffer.from([
+        48,
+        27,
+        48,
+        13,
+        6,
+        9,
+        42,
+        134,
+        72,
+        134,
+        247,
+        13,
+        1,
+        1,
+        1,
+        5,
+        0,
+        3,
+        10,
+        0,
+        48,
+        7,
+        2,
+        2,
+        0, // here is the leading 0
+        128, // prepended with leading 0
+        2,
+        1,
+        64, // not prepended with leading 0
+      ])
+    );
+  });
+
   test("Deconstructing public key works", () => {
     const priorGeneratedPublicKey = readFileSync(
       join(__dirname, "pubkey-test.der")

--- a/tests/unit/https.test.ts
+++ b/tests/unit/https.test.ts
@@ -19,9 +19,7 @@ describe("unit tests https", () => {
     const payload = JSON.stringify({ hello: "world" }) + "}";
     mockHttpsUri(uri, { responsePayload: payload });
     expect.assertions(1);
-    return expect(fetchJson(uri)).rejects.toThrow(
-      "Unexpected token } in JSON at position 17"
-    );
+    return expect(fetchJson(uri)).rejects.toThrow("JSON at position 17");
   });
 
   test("Fetch JSON error flow works: 404", () => {


### PR DESCRIPTION
*Issue #, if available:* #154

*Description of changes:* Fixes a bug in the DER encoder of aws-jwt-verify that does not add a leading 0-byte if the MSB (most significant bit) of the public key modulus is 1. In NodeJS this doesn't throw, because OpenSSL is friendly enough (?) to still parse the modulus as a positive number, but in bun it leads to the modulus being parsed as a negative number as @cirospaciari saw. I think that's actually right, because the number is supposed to be encoded in 2's complement per DER spec (https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#%5B%7B%22num%22%3A41%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22FitH%22%7D%2C799%5D).

(Also, had to fix a unit test that suddenly failed on me in Node v20, as the message changed slightly)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
