### PR TITLE
Fetch and parse the PEM ALB public key 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node-web-compat*.d.ts
 safe-json-parse.d.ts
 test-util.d.ts
 typing-util.d.ts
+fetcher-util.d.ts

--- a/src/fetcher-util.ts
+++ b/src/fetcher-util.ts
@@ -1,6 +1,16 @@
-import { JwtBaseError, JwtWithoutValidKidError, KidNotFoundInJwksError } from "./error";
+import {
+  JwtBaseError,
+  JwtWithoutValidKidError,
+  KidNotFoundInJwksError,
+} from "./error";
 import { JsonFetcher, SimpleBufferFetcher } from "./https";
-import { JwkWithKid, Jwks, JwksCache, PenaltyBox, SimpleJwksCache } from "./jwk";
+import {
+  JwkWithKid,
+  Jwks,
+  JwksCache,
+  PenaltyBox,
+  SimpleJwksCache,
+} from "./jwk";
 import crypto from "crypto";
 import { JwtHeader, JwtPayload } from "./jwt-model";
 
@@ -9,27 +19,29 @@ interface DecomposedJwt {
   payload: JwtPayload;
 }
 
-const albRegex = /https:\/\/public-keys.auth.elb.(?<region>[a-z0-9-]+).amazonaws.com\/(?<kid>[a-z0-9-]+)/;
+const albRegex =
+  /https:\/\/public-keys.auth.elb.(?<region>[a-z0-9-]+).amazonaws.com\/(?<kid>[a-z0-9-]+)/;
 
 export class AlbUriError extends JwtBaseError {}
 
 type FetchRequestOptions = Record<string, unknown>;
 
 export class AwsAlbJwksFetcher implements JsonFetcher {
-
   private fetcher;
 
   constructor(props?: { defaultRequestOptions?: FetchRequestOptions }) {
     this.fetcher = new SimpleBufferFetcher(props);
   }
 
-  public async fetch(uri: string, requestOptions?: FetchRequestOptions, data?: Buffer) {
-    return this.fetcher.fetch(uri,requestOptions,data).then((response) => {
+  public async fetch(
+    uri: string,
+    requestOptions?: FetchRequestOptions,
+    data?: Buffer
+  ) {
+    return this.fetcher.fetch(uri, requestOptions, data).then((response) => {
       const match = uri.match(albRegex);
-      if(!match){
-        throw new AlbUriError(
-          "Wrong URI for ALB public key"
-        );
+      if (!match) {
+        throw new AlbUriError("Wrong URI for ALB public key");
       }
 
       return {
@@ -50,26 +62,24 @@ export class AwsAlbJwksFetcher implements JsonFetcher {
 const KID_URI_VARIABLE = "{kid}";
 
 export class AwsAlbJwksCache implements JwksCache {
-
   private simpleJwksCache: SimpleJwksCache;
 
   constructor(props?: { penaltyBox?: PenaltyBox; fetcher?: JsonFetcher }) {
-    this.simpleJwksCache = new SimpleJwksCache(
-      { penaltyBox: props?.penaltyBox, fetcher: props?.fetcher ?? new AwsAlbJwksFetcher() }
-    );
+    this.simpleJwksCache = new SimpleJwksCache({
+      penaltyBox: props?.penaltyBox,
+      fetcher: props?.fetcher ?? new AwsAlbJwksFetcher(),
+    });
   }
 
-  private expandWithKid(jwksUri: string,decomposedJwt: DecomposedJwt):string{
+  private expandWithKid(jwksUri: string, decomposedJwt: DecomposedJwt): string {
     const kid = this.getKid(decomposedJwt);
-    if(jwksUri.indexOf(KID_URI_VARIABLE)<0){
-      throw new KidNotFoundInJwksError(
-        "kid not found in URI"
-      );
+    if (jwksUri.indexOf(KID_URI_VARIABLE) < 0) {
+      throw new KidNotFoundInJwksError("kid not found in URI");
     }
-    return jwksUri.replace(KID_URI_VARIABLE,encodeURIComponent(kid));
+    return jwksUri.replace(KID_URI_VARIABLE, encodeURIComponent(kid));
   }
 
-  private getKid(decomposedJwt: DecomposedJwt):string{
+  private getKid(decomposedJwt: DecomposedJwt): string {
     if (typeof decomposedJwt.header.kid !== "string") {
       throw new JwtWithoutValidKidError(
         "JWT header does not have valid kid claim"
@@ -78,29 +88,27 @@ export class AwsAlbJwksCache implements JwksCache {
     return decomposedJwt.header.kid;
   }
 
-  addJwks(): void {
+  public addJwks(): void {
     throw new Error("Method not implemented.");
   }
 
-  getJwks(): Promise<Jwks> {
-      throw new Error("Method not implemented.");
+  async getJwks(): Promise<Jwks> {
+    throw new Error("Method not implemented.");
   }
 
   public getCachedJwk(
     jwksUri: string,
     decomposedJwt: DecomposedJwt
   ): JwkWithKid {
-    const jwksUriExpanded = this.expandWithKid(jwksUri,decomposedJwt);
-    return this.simpleJwksCache.getCachedJwk(jwksUriExpanded,decomposedJwt);
+    const jwksUriExpanded = this.expandWithKid(jwksUri, decomposedJwt);
+    return this.simpleJwksCache.getCachedJwk(jwksUriExpanded, decomposedJwt);
   }
 
   public async getJwk(
     jwksUri: string,
     decomposedJwt: DecomposedJwt
   ): Promise<JwkWithKid> {
-    const jwksUriExpanded = this.expandWithKid(jwksUri,decomposedJwt);
-    return this.simpleJwksCache.getJwk(jwksUriExpanded,decomposedJwt);
+    const jwksUriExpanded = this.expandWithKid(jwksUri, decomposedJwt);
+    return this.simpleJwksCache.getJwk(jwksUriExpanded, decomposedJwt);
   }
-
-
 }

--- a/src/fetcher-util.ts
+++ b/src/fetcher-util.ts
@@ -1,0 +1,99 @@
+import { JwtBaseError, JwtWithoutValidKidError, KidNotFoundInJwksError } from "./error";
+import { JsonFetcher, SimpleJsonFetcher } from "./https";
+import { JwkWithKid, Jwks, JwksCache, PenaltyBox, SimpleJwksCache } from "./jwk";
+import { DecomposedJwt } from "./jwt";
+import crypto from "crypto";
+
+type AwsAlbJwks = string;
+
+// https://public-keys.auth.elb.eu-west-1.amazonaws.com/575d530c-54b0-43c3-8ce0-e7ed4dccdb8f
+const albRegex = /https:\/\/public-keys.auth.elb.(?<region>[a-z0-9-]+).amazonaws.com\/(?<kid>[a-z0-9-]+)/g;
+
+export class AlbUriError extends JwtBaseError {}
+
+export class AwsAlbJwksFetcher implements JsonFetcher {
+
+  private fetcher = new SimpleJsonFetcher();
+
+  public async fetch(...params: Parameters<JsonFetcher["fetch"]>) {
+    const uri = params[0];
+    const match = uri.match(albRegex);
+    if(!match){
+      throw new AlbUriError(
+        "Wrong URI for ALB public key"
+      );
+    }
+    return this.fetcher.fetch(...params).then((response) => {
+      return {
+        keys: [
+          {
+            kid: match.groups?.kid!,
+            kty: "RSA",
+            use: "sig",
+            ...crypto.createPublicKey(response as AwsAlbJwks).export({
+              format: "jwk",
+            }),
+          },
+        ],
+      };
+    });
+  }
+}
+
+const KID_URI_VARIABLE = "{kid}";
+
+export class AwsAlbJwksCache implements JwksCache {
+
+  private simpleJwksCache: SimpleJwksCache;
+
+  constructor(props?: { penaltyBox?: PenaltyBox; fetcher?: JsonFetcher }) {
+    this.simpleJwksCache = new SimpleJwksCache(
+      { penaltyBox: props?.penaltyBox, fetcher: props?.fetcher ?? new AwsAlbJwksFetcher() }
+    );
+  }
+
+  private expandWithKid(jwksUri: string,decomposedJwt: DecomposedJwt):string{
+    const kid = this.getKid(decomposedJwt);
+    if(jwksUri.indexOf(KID_URI_VARIABLE)<0){
+      throw new KidNotFoundInJwksError(
+        "kid not found in URI"
+      );
+    }
+    return jwksUri.replace(KID_URI_VARIABLE,kid);
+  }
+
+  private getKid(decomposedJwt: DecomposedJwt):string{
+    if (typeof decomposedJwt.header.kid !== "string") {
+      throw new JwtWithoutValidKidError(
+        "JWT header does not have valid kid claim"
+      );
+    }
+    return decomposedJwt.header.kid;
+  }
+
+  addJwks(): void {
+    throw new Error("Method not implemented.");
+  }
+
+  getJwks(): Promise<Jwks> {
+      throw new Error("Method not implemented.");
+  }
+
+  public getCachedJwk(
+    jwksUri: string,
+    decomposedJwt: DecomposedJwt
+  ): JwkWithKid {
+    const jwksUriExpanded = this.expandWithKid(jwksUri,decomposedJwt);
+    return this.simpleJwksCache.getCachedJwk(jwksUriExpanded,decomposedJwt);
+  }
+
+  public async getJwk(
+    jwksUri: string,
+    decomposedJwt: DecomposedJwt
+  ): Promise<JwkWithKid> {
+    const jwksUriExpanded = this.expandWithKid(jwksUri,decomposedJwt);
+    return this.simpleJwksCache.getJwk(jwksUriExpanded,decomposedJwt);
+  }
+
+
+}

--- a/src/fetcher-util.ts
+++ b/src/fetcher-util.ts
@@ -59,7 +59,7 @@ export class AwsAlbJwksCache implements JwksCache {
         "kid not found in URI"
       );
     }
-    return jwksUri.replace(KID_URI_VARIABLE,kid);
+    return jwksUri.replace(KID_URI_VARIABLE,encodeURIComponent(kid));
   }
 
   private getKid(decomposedJwt: DecomposedJwt):string{

--- a/src/https-common.ts
+++ b/src/https-common.ts
@@ -18,14 +18,7 @@ export function validateHttpsJsonResponse(
   statusCode?: number,
   contentType?: string
 ): void {
-  if (statusCode === 429) {
-    throw new FetchError(uri, "Too many requests");
-  } else if (statusCode !== 200) {
-    throw new NonRetryableFetchError(
-      uri,
-      `Status code is ${statusCode}, expected 200`
-    );
-  }
+  validateHttpsBufferResponse(uri, statusCode);
   if (
     !contentType ||
     !contentType.toLowerCase().startsWith("application/json")
@@ -33,6 +26,27 @@ export function validateHttpsJsonResponse(
     throw new NonRetryableFetchError(
       uri,
       `Content-type is "${contentType}", expected "application/json"`
+    );
+  }
+}
+
+/**
+ * Sanity check a HTTPS response where we expect to get JSON data back
+ *
+ * @param uri the uri that was being requested
+ * @param statusCode the HTTP status code, should be 200
+ * @returns void - throws an error if the status code or content type aren't as expected
+ */
+export function validateHttpsBufferResponse(
+  uri: string,
+  statusCode?: number,
+): void {
+  if (statusCode === 429) {
+    throw new FetchError(uri, "Too many requests");
+  } else if (statusCode !== 200) {
+    throw new NonRetryableFetchError(
+      uri,
+      `Status code is ${statusCode}, expected 200`
     );
   }
 }

--- a/src/https-common.ts
+++ b/src/https-common.ts
@@ -39,7 +39,7 @@ export function validateHttpsJsonResponse(
  */
 export function validateHttpsBufferResponse(
   uri: string,
-  statusCode?: number,
+  statusCode?: number
 ): void {
   if (statusCode === 429) {
     throw new FetchError(uri, "Too many requests");

--- a/src/https.ts
+++ b/src/https.ts
@@ -50,16 +50,16 @@ export interface BufferFetcher<ResultType extends Uint8Array = Uint8Array> {
  * Use the decorator pattern
  */
 export class RetryableFetcher<ResultType> {
-
   defaultRequestOptions: FetchRequestOptions;
 
   constructor(
-    private fetcher:(
-    uri: string,
-    requestOptions?: Record<string, unknown>,
-    data?: Uint8Array
-  ) => Promise<ResultType>,
-  props?: { defaultRequestOptions?: FetchRequestOptions }) {
+    private fetcher: (
+      uri: string,
+      requestOptions?: Record<string, unknown>,
+      data?: Uint8Array
+    ) => Promise<ResultType>,
+    props?: { defaultRequestOptions?: FetchRequestOptions }
+  ) {
     this.defaultRequestOptions = {
       timeout: nodeWebCompat.defaultFetchTimeouts.socketIdle,
       responseTimeout: nodeWebCompat.defaultFetchTimeouts.response,
@@ -67,11 +67,11 @@ export class RetryableFetcher<ResultType> {
     };
   }
 
-  public async fetch (
+  public async fetch(
     uri: string,
     requestOptions?: FetchRequestOptions,
     data?: Buffer
-  ):Promise<ResultType>{
+  ): Promise<ResultType> {
     requestOptions = { ...this.defaultRequestOptions, ...requestOptions };
     try {
       return await this.fetcher(uri, requestOptions, data);
@@ -89,24 +89,25 @@ export class RetryableFetcher<ResultType> {
  *
  * @param defaultRequestOptions - The default RequestOptions to use on individual HTTPS requests
  */
-export class SimpleJsonFetcher extends RetryableFetcher<Json> implements JsonFetcher {
-  
+export class SimpleJsonFetcher
+  extends RetryableFetcher<Json>
+  implements JsonFetcher
+{
   constructor(props?: { defaultRequestOptions?: FetchRequestOptions }) {
     super(fetchJson, props);
   }
-
 }
-
 
 /**
  * HTTPS Fetcher for URIs with Buffer body
  *
  * @param defaultRequestOptions - The default RequestOptions to use on individual HTTPS requests
  */
-export class SimpleBufferFetcher extends RetryableFetcher<Buffer> implements BufferFetcher {
-
+export class SimpleBufferFetcher
+  extends RetryableFetcher<Buffer>
+  implements BufferFetcher
+{
   constructor(props?: { defaultRequestOptions?: FetchRequestOptions }) {
     super(fetchBuffer, props);
   }
-
 }

--- a/src/node-web-compat-node.ts
+++ b/src/node-web-compat-node.ts
@@ -6,7 +6,7 @@
 import { createPublicKey, createVerify, KeyObject } from "crypto";
 import { RsaSignatureJwk } from "./jwk.js";
 import { constructPublicKeyInDerFormat } from "./asn1.js";
-import { fetchJson } from "./https-node.js";
+import { fetchBuffer, fetchJson } from "./https-node.js";
 import { NodeWebCompat } from "./node-web-compat.js";
 
 /**
@@ -20,6 +20,7 @@ enum JwtSignatureAlgorithms {
 
 export const nodeWebCompat: NodeWebCompat = {
   fetchJson,
+  fetchBuffer,
   transformJwkToKeyObjectSync: (jwk: RsaSignatureJwk) =>
     createPublicKey({
       key: constructPublicKeyInDerFormat(

--- a/src/node-web-compat-web.ts
+++ b/src/node-web-compat-web.ts
@@ -52,9 +52,7 @@ export const nodeWebCompat: NodeWebCompat = {
     return response.text().then((text) => safeJsonParse(text) as ResultType);
   },
   fetchBuffer: () => {
-    throw new NotSupportedError(
-      "Fetch buffer not supported"
-    );
+    throw new NotSupportedError("Fetch buffer not supported");
   },
   defaultFetchTimeouts: {
     response: 3000,

--- a/src/node-web-compat-web.ts
+++ b/src/node-web-compat-web.ts
@@ -51,6 +51,11 @@ export const nodeWebCompat: NodeWebCompat = {
     );
     return response.text().then((text) => safeJsonParse(text) as ResultType);
   },
+  fetchBuffer: () => {
+    throw new NotSupportedError(
+      "Fetch buffer not supported"
+    );
+  },
   defaultFetchTimeouts: {
     response: 3000,
   },

--- a/src/node-web-compat.ts
+++ b/src/node-web-compat.ts
@@ -33,6 +33,11 @@ export interface NodeWebCompat {
     requestOptions?: Record<string, unknown>,
     data?: Uint8Array
   ) => Promise<ResultType>;
+  fetchBuffer: <ResultType extends Buffer>(
+    uri: string,
+    requestOptions?: Record<string, unknown>,
+    data?: Uint8Array
+  ) => Promise<ResultType>;
   defaultFetchTimeouts: {
     socketIdle?: number; // socket idle timeout (Only supported by Node.js runtime)
     response: number; // total round trip timeout

--- a/tests/unit/albresponse-test.pem
+++ b/tests/unit/albresponse-test.pem
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGBJCbjNusVteS//606LS3fgYrhQy
+vfAh+GbOfy2n7rWgG433Rtb4C/Gxyh6xVoTuvI8hKOqx4qCKjoflk7nGaQ==
+-----END PUBLIC KEY-----

--- a/tests/unit/fetcher-util.test.ts
+++ b/tests/unit/fetcher-util.test.ts
@@ -198,7 +198,7 @@ describe("unit tests https", () => {
       error = err as Error;
     }
     expect(error).toBeInstanceOf(KidNotFoundInJwksError);
-    expect(fetcher.fetch).toHaveBeenCalledTimes(2);
+    expect(fetcher.fetch).toHaveBeenCalledTimes(3);
     penaltyBox.release(jwksUri);
   });
 });

--- a/tests/unit/fetcher-util.test.ts
+++ b/tests/unit/fetcher-util.test.ts
@@ -1,0 +1,204 @@
+import { JwtWithoutValidKidError, KidNotFoundInJwksError, WaitPeriodNotYetEndedJwkError } from "../../src/error";
+import { AlbUriError, AwsAlbJwksCache, AwsAlbJwksFetcher } from "../../src/fetcher-util";
+import { SimplePenaltyBox } from "../../src/jwk";
+import { mockHttpsUri, throwOnUnusedMocks } from "./test-util";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("unit tests https", () => {
+  const jwksUri = "https://public-keys.auth.elb.eu-west-1.amazonaws.com/{kid}";
+  const publicKeyAlbResponse = readFileSync(
+    join(__dirname, "albresponse-test.pem")
+  );
+  const jwk = {
+    kid: "abcdefgh-1234-ijkl-5678-mnopqrstuvwx",
+    use: "sig",
+    kty: 'EC',
+    x: 'GBJCbjNusVteS__606LS3fgYrhQyvfAh-GbOfy2n7rU',
+    y: 'oBuN90bW-AvxscoesVaE7ryPISjqseKgio6H5ZO5xmk',
+    crv: 'P-256'
+  }
+  const jwks = {
+    keys: [jwk]
+  };
+  const getDecomposedJwt = (kid?:string ) => ({
+    header: {
+      alg: "EC256",
+      kid: kid ?? jwk.kid,
+    },
+    payload: {},
+  });
+
+  afterEach(() => {
+    throwOnUnusedMocks();
+  });
+
+  test("ALB JSON fetcher works", () => {
+    mockHttpsUri(jwksUri, { responsePayload: publicKeyAlbResponse });
+    expect.assertions(1);
+    return expect(new AwsAlbJwksFetcher().fetch(jwksUri)).resolves.toEqual(jwks);
+  });
+
+  test("ALB JSON fetcher does not validate alb public key URI", () => {
+      const wrongUri = `https://public-keys.auth.elb.eu-west-1.amazon.wrong/${jwk.kid}`
+      mockHttpsUri(wrongUri, { responsePayload: publicKeyAlbResponse });
+      expect.assertions(1);
+      return expect(new AwsAlbJwksFetcher().fetch(wrongUri)).rejects.toThrow(AlbUriError);
+  });
+
+  test("ALB JSON fetcher does retry once", () => {
+    class TcpError extends Error {}
+    expect.assertions(1);
+    mockHttpsUri(jwksUri, new TcpError("Some TCP error occured"));
+    mockHttpsUri(jwksUri, { responsePayload: publicKeyAlbResponse });
+    return expect(new AwsAlbJwksFetcher().fetch(jwksUri)).resolves.toEqual(jwks);
+  });
+
+  test("ALB JSON fetcher does retry HTTP 429", () => {
+    expect.assertions(1);
+    mockHttpsUri(jwksUri, {
+      responseStatus: 429,
+      responsePayload: "WE'RE BUSY RIGHT NOW",
+    });
+    mockHttpsUri(jwksUri, { responsePayload: publicKeyAlbResponse });
+    return expect(new AwsAlbJwksFetcher().fetch(jwksUri)).resolves.toEqual(jwks);
+  });
+
+  test("ALB JSON fetcher does not retry twice", () => {
+    class TcpError extends Error {}
+    expect.assertions(1);
+    mockHttpsUri(jwksUri, new TcpError("1st TCP Error"));
+    mockHttpsUri(jwksUri, new TcpError("2nd TCP Error"));
+    return expect(new AwsAlbJwksFetcher().fetch(jwksUri)).rejects.toThrow(
+      `Failed to fetch ${jwksUri}: 2nd TCP Error`
+    );
+  });
+
+  test("ALB JSON fetcher does not retry non-retryable errors", () => {
+    expect.assertions(1);
+    mockHttpsUri(jwksUri, { responseStatus: 500, responsePayload: "Nope!\nError" });
+    return expect(new AwsAlbJwksFetcher().fetch(jwksUri)).rejects.toThrow(
+      `Failed to fetch ${jwksUri}: Status code is 500, expected 200`
+    );
+  });
+
+  test("ALB JSON fetcher uses defaults provided to the constructor", () => {
+    mockHttpsUri(jwksUri, { responsePayload: publicKeyAlbResponse });
+    expect.assertions(1);
+    return expect(
+      new AwsAlbJwksFetcher({
+        defaultRequestOptions: { timeout: 100, responseTimeout: 150 },
+      }).fetch(jwksUri)
+    ).resolves.toEqual(jwks);
+  });
+
+
+  test("ALB JWKS cache returns JWK", () => {
+    const jwksCache = new AwsAlbJwksCache({
+      fetcher: { fetch: async () => jwks },
+    });
+    expect.assertions(1);
+    return expect(
+      jwksCache.getJwk(jwksUri, getDecomposedJwt())
+    ).resolves.toEqual(jwk);
+  });
+
+  test("ALB JWKS with no kid variable in URI", () => {
+    const jwksCache = new AwsAlbJwksCache({
+      fetcher: { fetch: async () => jwks },
+    });
+    expect.assertions(1);
+    return expect(
+      jwksCache.getJwk("https://public-keys.auth.elb.eu-west-1.amazonaws.com/", getDecomposedJwt())
+    ).rejects.toThrow(KidNotFoundInJwksError);
+  });
+
+  test("ALB JWKS cache returns cached JWK", () => {
+    const jwksCache = new AwsAlbJwksCache({
+      fetcher: { fetch: async () => jwks },
+    });
+    expect(
+       jwksCache.getJwk(jwksUri, getDecomposedJwt())
+       .then(()=>jwksCache.getCachedJwk(jwksUri, getDecomposedJwt()))
+    ).resolves.toEqual(jwk);
+  });
+
+  test("ALB JWKS cache error flow: kid empty", () => {
+    const jwksCache = new AwsAlbJwksCache();
+    expect.assertions(1);
+    return expect(
+      jwksCache.getJwk(jwksUri, { header: { alg: "EC256" }, payload: {} })
+    ).rejects.toThrow(JwtWithoutValidKidError);
+  });
+
+
+  test("ALB JWKS cache fetches URI one attempt at a time", async () => {
+    /**
+     * Test what happens when the the JWKS URI is requested multiple times in parallel
+     * (e.g. in parallel promises). When this happens only 1 actual HTTPS request should
+     * be made to the JWKS URI.
+     */
+    const fetcher = { fetch: jest.fn(async () => jwks) };
+    const jwksCache = new AwsAlbJwksCache({
+      fetcher,
+    });
+    const promise1 = jwksCache.getJwk(jwksUri, getDecomposedJwt());
+    const promise2 = jwksCache.getJwk(jwksUri, getDecomposedJwt());
+    expect.assertions(2);
+    expect(promise1).toEqual(promise2);
+    await Promise.all([promise1, promise2]);
+    expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("ALB JWKS cache throws error if wait time did not yet pass", async () => {
+    /**
+     * Test what happens when the the JWKS URI would need te be fetched, but the last time
+     * it was fetched, the requested JWK was not found in the JWKS. A new fetch of the JWKS URI will only
+     * be executed after the wait time has lapsed. If the wait time did not lapse yet, an error should be thrown.
+     * Test that this indeed happens. Also, test that requests for JWKs that are already in the cache, still
+     * sucessfully return the JWK. After the wait time lapses, the JWKS URI may be fetched again.
+     */
+    const fetcher = { fetch: jest.fn(async () => jwks) };
+    const waitSeconds = 0.5;
+    const penaltyBox = new SimplePenaltyBox({ waitSeconds });
+    const jwksCache = new AwsAlbJwksCache({
+      fetcher,
+      penaltyBox,
+    });
+    let error: Error | undefined = undefined;
+    let wait: Promise<void> | undefined = undefined;
+
+    // First: try to fetch JWK that does not exist
+    try {
+      await jwksCache.getJwk(jwksUri, getDecomposedJwt("otherkid"));
+    } catch (err) {
+      error = err as Error;
+      wait = new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
+    }
+    expect.assertions(5);
+    expect(error).toBeInstanceOf(KidNotFoundInJwksError);
+
+    // Then: try to fetch JWK that does not exist, this should throw an error
+    try {
+      await jwksCache.getJwk(jwksUri, getDecomposedJwt("otherkid"));
+    } catch (err) {
+      error = err as Error;
+    }
+    expect(error).toBeInstanceOf(WaitPeriodNotYetEndedJwkError);
+
+    // Then: ensure we are still able to fetch cached JWK's without getting a wait error
+    const jwk = await jwksCache.getJwk(jwksUri, getDecomposedJwt());
+    expect(jwk).toEqual(jwk);
+
+    // Then, ensure that after the wait period we can try again
+    await wait!;
+    try {
+      await jwksCache.getJwk(jwksUri, getDecomposedJwt("otherkid"));
+    } catch (err) {
+      error = err as Error;
+    }
+    expect(error).toBeInstanceOf(KidNotFoundInJwksError);
+    expect(fetcher.fetch).toHaveBeenCalledTimes(2);
+    penaltyBox.release(jwksUri);
+  });
+});

--- a/tests/unit/fetcher-util.test.ts
+++ b/tests/unit/fetcher-util.test.ts
@@ -1,5 +1,13 @@
-import { JwtWithoutValidKidError, KidNotFoundInJwksError, WaitPeriodNotYetEndedJwkError } from "../../src/error";
-import { AlbUriError, AwsAlbJwksCache, AwsAlbJwksFetcher } from "../../src/fetcher-util";
+import {
+  JwtWithoutValidKidError,
+  KidNotFoundInJwksError,
+  WaitPeriodNotYetEndedJwkError,
+} from "../../src/error";
+import {
+  AlbUriError,
+  AwsAlbJwksCache,
+  AwsAlbJwksFetcher,
+} from "../../src/fetcher-util";
 import { SimplePenaltyBox } from "../../src/jwk";
 import { mockHttpsUri, throwOnUnusedMocks } from "./test-util";
 import { readFileSync } from "fs";
@@ -15,15 +23,15 @@ describe("unit tests https", () => {
   const jwk = {
     kid: kid,
     use: "sig",
-    kty: 'EC',
-    x: 'GBJCbjNusVteS__606LS3fgYrhQyvfAh-GbOfy2n7rU',
-    y: 'oBuN90bW-AvxscoesVaE7ryPISjqseKgio6H5ZO5xmk',
-    crv: 'P-256'
-  }
-  const jwks = {
-    keys: [jwk]
+    kty: "EC",
+    x: "GBJCbjNusVteS__606LS3fgYrhQyvfAh-GbOfy2n7rU",
+    y: "oBuN90bW-AvxscoesVaE7ryPISjqseKgio6H5ZO5xmk",
+    crv: "P-256",
   };
-  const getDecomposedJwt = (kidParam?:string ) => ({
+  const jwks = {
+    keys: [jwk],
+  };
+  const getDecomposedJwt = (kidParam?: string) => ({
     header: {
       alg: "EC256",
       kid: kidParam ?? kid,
@@ -38,14 +46,18 @@ describe("unit tests https", () => {
   test("ALB JSON fetcher works", () => {
     mockHttpsUri(jwksUriExpanded, { responsePayload: publicKeyAlbResponse });
     expect.assertions(1);
-    return expect(new AwsAlbJwksFetcher().fetch(jwksUriExpanded)).resolves.toEqual(jwks);
+    return expect(
+      new AwsAlbJwksFetcher().fetch(jwksUriExpanded)
+    ).resolves.toEqual(jwks);
   });
 
   test("ALB JSON fetcher does not validate alb public key URI", () => {
-      const wrongUri = `https://public-keys.auth.elb.eu-west-1.amazon.wrong/${jwk.kid}`
-      mockHttpsUri(wrongUri, { responsePayload: publicKeyAlbResponse });
-      expect.assertions(1);
-      return expect(new AwsAlbJwksFetcher().fetch(wrongUri)).rejects.toThrow(AlbUriError);
+    const wrongUri = `https://public-keys.auth.elb.eu-west-1.amazon.wrong/${jwk.kid}`;
+    mockHttpsUri(wrongUri, { responsePayload: publicKeyAlbResponse });
+    expect.assertions(1);
+    return expect(new AwsAlbJwksFetcher().fetch(wrongUri)).rejects.toThrow(
+      AlbUriError
+    );
   });
 
   test("ALB JSON fetcher does retry once", () => {
@@ -53,7 +65,9 @@ describe("unit tests https", () => {
     expect.assertions(1);
     mockHttpsUri(jwksUriExpanded, new TcpError("Some TCP error occured"));
     mockHttpsUri(jwksUriExpanded, { responsePayload: publicKeyAlbResponse });
-    return expect(new AwsAlbJwksFetcher().fetch(jwksUriExpanded)).resolves.toEqual(jwks);
+    return expect(
+      new AwsAlbJwksFetcher().fetch(jwksUriExpanded)
+    ).resolves.toEqual(jwks);
   });
 
   test("ALB JSON fetcher does retry HTTP 429", () => {
@@ -63,7 +77,9 @@ describe("unit tests https", () => {
       responsePayload: "WE'RE BUSY RIGHT NOW",
     });
     mockHttpsUri(jwksUriExpanded, { responsePayload: publicKeyAlbResponse });
-    return expect(new AwsAlbJwksFetcher().fetch(jwksUriExpanded)).resolves.toEqual(jwks);
+    return expect(
+      new AwsAlbJwksFetcher().fetch(jwksUriExpanded)
+    ).resolves.toEqual(jwks);
   });
 
   test("ALB JSON fetcher does not retry twice", () => {
@@ -71,15 +87,20 @@ describe("unit tests https", () => {
     expect.assertions(1);
     mockHttpsUri(jwksUriExpanded, new TcpError("1st TCP Error"));
     mockHttpsUri(jwksUriExpanded, new TcpError("2nd TCP Error"));
-    return expect(new AwsAlbJwksFetcher().fetch(jwksUriExpanded)).rejects.toThrow(
-      `Failed to fetch ${jwksUriExpanded}: 2nd TCP Error`
-    );
+    return expect(
+      new AwsAlbJwksFetcher().fetch(jwksUriExpanded)
+    ).rejects.toThrow(`Failed to fetch ${jwksUriExpanded}: 2nd TCP Error`);
   });
 
   test("ALB JSON fetcher does not retry non-retryable errors", () => {
     expect.assertions(1);
-    mockHttpsUri(jwksUriExpanded, { responseStatus: 500, responsePayload: "Nope!\nError" });
-    return expect(new AwsAlbJwksFetcher().fetch(jwksUriExpanded)).rejects.toThrow(
+    mockHttpsUri(jwksUriExpanded, {
+      responseStatus: 500,
+      responsePayload: "Nope!\nError",
+    });
+    return expect(
+      new AwsAlbJwksFetcher().fetch(jwksUriExpanded)
+    ).rejects.toThrow(
       `Failed to fetch ${jwksUriExpanded}: Status code is 500, expected 200`
     );
   });
@@ -93,7 +114,6 @@ describe("unit tests https", () => {
       }).fetch(jwksUriExpanded)
     ).resolves.toEqual(jwks);
   });
-
 
   test("ALB JWKS cache returns JWK", () => {
     const jwksCache = new AwsAlbJwksCache({
@@ -111,7 +131,10 @@ describe("unit tests https", () => {
     });
     expect.assertions(1);
     return expect(
-      jwksCache.getJwk("https://public-keys.auth.elb.eu-west-1.amazonaws.com/", getDecomposedJwt())
+      jwksCache.getJwk(
+        "https://public-keys.auth.elb.eu-west-1.amazonaws.com/",
+        getDecomposedJwt()
+      )
     ).rejects.toThrow(KidNotFoundInJwksError);
   });
 
@@ -120,8 +143,9 @@ describe("unit tests https", () => {
       fetcher: { fetch: async () => jwks },
     });
     expect(
-       jwksCache.getJwk(jwksUri, getDecomposedJwt())
-       .then(()=>jwksCache.getCachedJwk(jwksUri, getDecomposedJwt()))
+      jwksCache
+        .getJwk(jwksUri, getDecomposedJwt())
+        .then(() => jwksCache.getCachedJwk(jwksUri, getDecomposedJwt()))
     ).resolves.toEqual(jwk);
   });
 
@@ -133,6 +157,18 @@ describe("unit tests https", () => {
     ).rejects.toThrow(JwtWithoutValidKidError);
   });
 
+  test("ALB JWKS add cache return not implemented exception", () => {
+    const jwksCache = new AwsAlbJwksCache();
+    return expect(jwksCache.addJwks).toThrow("Method not implemented.");
+  });
+
+  test("ALB JWKS get JWKS return not implemented exception", () => {
+    const jwksCache = new AwsAlbJwksCache();
+    expect.assertions(1);
+    return expect(jwksCache.getJwks()).rejects.toThrow(
+      "Method not implemented."
+    );
+  });
 
   test("ALB JWKS cache fetches URI one attempt at a time", async () => {
     /**

--- a/tests/unit/https.test.ts
+++ b/tests/unit/https.test.ts
@@ -19,9 +19,7 @@ describe("unit tests https", () => {
     const payload = JSON.stringify({ hello: "world" }) + "}";
     mockHttpsUri(uri, { responsePayload: payload });
     expect.assertions(1);
-    return expect(fetchJson(uri)).rejects.toThrow(
-      "Unexpected token } in JSON at position 17"
-    );
+    return expect(fetchJson(uri)).rejects.toThrow("JSON at position 17");
   });
 
   test("Fetch JSON error flow works: 404", () => {


### PR DESCRIPTION
*Issue https://github.com/awslabs/aws-jwt-verify/issues/109*

*Description of changes:*
Ability to read and parse PEM/PKCS8 public key for the node version only (not compatible with webapp)
- modify node-web-compat to add a bufferFetcher. Add the implementation for this bufferFetcher only for the node version.
- add the SimpleBufferFetcher that use the bufferFetcher above.
- add the AwsAlbJwksFetcher using the SimpleBufferFetcher in order to transform the PEM into a JWKS.
- add the AwsAlbJwksCache using the AwsAlbJwksFetcher. Only methods `getJwk` and `getCachedJwk` are implemented because, to retrieve the public key forn the ALB, the URI has the kid in the URI: `https://public-keys.auth.elb.eu-west-1.amazonaws.com/{kid}`. It means that we can only load the public key and put it in the cache after receiving the JWT token to validate. A really simple mechanism of expend is implemented that consist only to replace the variable {kid} by the kid of the JWT token (leven simplier than level1 of the RFC https://www.rfc-editor.org/rfc/rfc6570).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
