### PR TITLE
fix: update typehint for Json type to also consider undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS JWT Verify
+# AWS JWT Verify.
 
 **JavaScript** library for **verifying** JWTs signed by **Amazon Cognito**, and any **OIDC-compatible IDP** that signs JWTs with **RS256** / **RS384** / **RS512** / **ES256** / **ES384** / **ES512**.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS JWT Verify.
+# AWS JWT Verify
 
 **JavaScript** library for **verifying** JWTs signed by **Amazon Cognito**, and any **OIDC-compatible IDP** that signs JWTs with **RS256** / **RS384** / **RS512** / **ES256** / **ES384** / **ES512**.
 

--- a/src/safe-json-parse.ts
+++ b/src/safe-json-parse.ts
@@ -4,7 +4,7 @@
 // Utility to parse JSON safely
 
 /** JSON type */
-export type Json = null | string | number | boolean | Json[] | JsonObject | undefined;
+export type Json = undefined | null | string | number | boolean | Json[] | JsonObject;
 
 /** JSON Object type */
 export type JsonObject = { [name: string]: Json };

--- a/src/safe-json-parse.ts
+++ b/src/safe-json-parse.ts
@@ -4,7 +4,7 @@
 // Utility to parse JSON safely
 
 /** JSON type */
-export type Json = null | string | number | boolean | Json[] | JsonObject;
+export type Json = null | string | number | boolean | Json[] | JsonObject | undefined;
 
 /** JSON Object type */
 export type JsonObject = { [name: string]: Json };

--- a/src/safe-json-parse.ts
+++ b/src/safe-json-parse.ts
@@ -4,7 +4,14 @@
 // Utility to parse JSON safely
 
 /** JSON type */
-export type Json = undefined | null | string | number | boolean | Json[] | JsonObject;
+export type Json =
+  | undefined
+  | null
+  | string
+  | number
+  | boolean
+  | Json[]
+  | JsonObject;
 
 /** JSON Object type */
 export type JsonObject = { [name: string]: Json };


### PR DESCRIPTION
*Issue #, if available:*

Currently, since the `JSON` type doesn't support undefined, and `CognitoIdTokenPayload` is an intersection type between `CognitoIdTokenFields & JsonObject`, the type `CognitoIdTokenPayload`, cannot be extended via an interface as follows:

```
interface CognitoTokenPayload extends CognitoIdTokenPayload {
    'custom:last_name'?: string;
}
```

The above line ends up reporting the following error
```
TS2411: Property  "cognito:groups"  of type  string[] | undefined  is not assignable to  string  index type  Json 
```


*Description of changes:*

Add an extra typehint in the `JSON` type


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
