### PR TITLE
fix/ecdsa verification to use raw signature format per jwa spec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,5 +27,6 @@ jobs:
           npm run test:install
           npm run test:import
           npm run test:browser
+          npm run test:speed
         env:
           CI: "true"

--- a/src/node-web-compat-node.ts
+++ b/src/node-web-compat-node.ts
@@ -38,7 +38,14 @@ export const nodeWebCompat: NodeWebCompat = {
     // eslint-disable-next-line security/detect-object-injection
     createVerify(JwtSignatureAlgorithms[alg])
       .update(jwsSigningInput)
-      .verify(keyObject as KeyObject, signature, "base64"),
+      .verify(
+        {
+          key: keyObject as KeyObject,
+          dsaEncoding: "ieee-p1363", // Signature format r || s (not used for RSA)
+        },
+        signature,
+        "base64"
+      ),
   verifySignatureAsync: async ({
     alg,
     keyObject,
@@ -48,7 +55,14 @@ export const nodeWebCompat: NodeWebCompat = {
     // eslint-disable-next-line security/detect-object-injection
     createVerify(JwtSignatureAlgorithms[alg])
       .update(jwsSigningInput)
-      .verify(keyObject as KeyObject, signature, "base64"),
+      .verify(
+        {
+          key: keyObject as KeyObject,
+          dsaEncoding: "ieee-p1363", // Signature format r || s (not used for RSA)
+        },
+        signature,
+        "base64"
+      ),
   defaultFetchTimeouts: {
     socketIdle: 1500,
     response: 3000,

--- a/tests/vite-app/cypress/e2e/unittests.cy.ts
+++ b/tests/vite-app/cypress/e2e/unittests.cy.ts
@@ -13,6 +13,8 @@ import {
   JWKSURI,
   VALID_TOKEN,
   VALID_TOKEN_FOR_JWK_WITHOUT_ALG,
+  VALID_TOKEN_ES256,
+  VALID_TOKEN_ES512,
   EXPIRED_TOKEN,
   NOT_YET_VALID_TOKEN,
 } from "../fixtures/example-token-data.json";
@@ -39,6 +41,28 @@ describe("unit tests", () => {
       jwksUri: JWKSURI,
     });
     const payload = await verifier.verify(VALID_TOKEN);
+
+    expect(payload).to.exist;
+  });
+
+  it("valid token - es256", async () => {
+    const verifier = JwtVerifier.create({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      jwksUri: JWKSURI,
+    });
+    const payload = await verifier.verify(VALID_TOKEN_ES256);
+
+    expect(payload).to.exist;
+  });
+
+  it("valid token - es512", async () => {
+    const verifier = JwtVerifier.create({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      jwksUri: JWKSURI,
+    });
+    const payload = await verifier.verify(VALID_TOKEN_ES512);
 
     expect(payload).to.exist;
   });

--- a/tests/vite-app/util/generateExampleTokens.ts
+++ b/tests/vite-app/util/generateExampleTokens.ts
@@ -68,6 +68,8 @@ const tokendata = {
   EXPIRED_TOKEN: "",
   NOT_YET_VALID_TOKEN: "",
   VALID_TOKEN_FOR_JWK_WITHOUT_ALG: "",
+  VALID_TOKEN_ES256: "",
+  VALID_TOKEN_ES512: "",
 };
 
 const main = async () => {
@@ -78,10 +80,23 @@ const main = async () => {
   const { privateKey: privateKeyForJwkWithoutAlg, jwk: jwkWithoutAlg } =
     generateKeyPair({ kty: "RSA", kid: randomUUID() });
   delete jwkWithoutAlg.alg;
-  const jwks = { keys: [jwk, jwkWithoutAlg] };
+  const { privateKey: privateKeyEs256, jwk: jwkEs256 } = generateKeyPair({
+    kty: "EC",
+    kid: randomUUID(),
+    alg: "ES256",
+  });
+  const { privateKey: privateKeyEs512, jwk: jwkEs512 } = generateKeyPair({
+    kty: "EC",
+    kid: randomUUID(),
+    alg: "ES512",
+  });
+
+  const jwks = { keys: [jwk, jwkWithoutAlg, jwkEs256, jwkEs512] };
 
   const jwtHeader = { kid: jwk.kid, alg: "RS256" };
   const jwtHeaderForJwkWithoutAlg = { kid: jwkWithoutAlg.kid, alg: "RS256" };
+  const jwtHeaderEs256 = { kid: jwkEs256.kid, alg: "ES256" };
+  const jwtHeaderEs512 = { kid: jwkEs512.kid, alg: "ES512" };
 
   saveFile("public", JWKSFILE, jwks);
   saveFile(join("cypress", "fixtures"), JWKSFILE, jwks);
@@ -95,6 +110,16 @@ const main = async () => {
     jwtHeaderForJwkWithoutAlg,
     validTokenPayload,
     privateKeyForJwkWithoutAlg
+  );
+  tokendata.VALID_TOKEN_ES256 = signJwt(
+    jwtHeaderEs256,
+    validTokenPayload,
+    privateKeyEs256
+  );
+  tokendata.VALID_TOKEN_ES512 = signJwt(
+    jwtHeaderEs512,
+    validTokenPayload,
+    privateKeyEs512
   );
   tokendata.EXPIRED_TOKEN = signJwt(jwtHeader, expiredTokenPayload, privateKey);
   tokendata.NOT_YET_VALID_TOKEN = signJwt(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixed ES256, ES384 and ES512 implementation: these should use raw signature format (r || s, as per JWA spec) but Node.js uses ASN.1 DER format by default. This can be switched to raw format by providing `dsaEncoding: "ieee-p1363"` which I added (thanks for the tip @NicolasViaud).

Also discovered that the browser implementation did not support the ECDSA formats at all yet, so added that.

And as icing on the cake, I finally fixed the browser test scrips so it doesn't orphan Vite processes anymore as it sometimes did! 🎉 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
