### PR TITLE
feat: Allow issuer null

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ See all verify parameters for JWTs from any IDP [here](#JwtVerifier-verify-param
 
 ### Non-standard IDPs
 
-For special cases you may want to use the library more raw:
+To make special cases work, you can use lower level constructs directly:
 
 ```typescript
-import { verifyJwt } from "aws-jwt-verify/jwt-verifier"; // there is also verifyJwtSync() for if you already have the JWK(S) ready
+import { verifyJwt } from "aws-jwt-verify/jwt-verifier"; // there is also verifyJwtSync() for if you already have the JWK(S) at hand
 import { SimpleJwksCache } from "aws-jwt-verify/jwk";
 
+// E.g. use SimpleJwksCache to fetch and cache JSON Web Key Sets (JWKS)
 const jwksCache = new SimpleJwksCache();
 
 try {
@@ -72,8 +73,8 @@ try {
     "eyJraWQeyJhdF9oYXNoIjoidk...", // the JWT as string
     "https://example.com/.well-known/jwks.json", // set this to the JWKS uri from your OpenID configuration
     {
-      issuer: "<iss>", // set this to the expected iss claim on the JWT
-      audience: "<aud>", // set this to the expected aud claim on the JWT
+      issuer: "<iss>", // set this to the expected iss claim on the JWT (or to null, to skip this check)
+      audience: "<aud>", // set this to the expected aud claim on the JWT (or to null, to skip this check)
     },
     jwksCache.getJwk.bind(jwksCache) // use JWKS cache (optional)
   );
@@ -90,7 +91,7 @@ try {
 - Support both **Amazon Cognito** as well as any other **OIDC-compatible IDP** as first class citizen.
 - **0** runtime dependencies, batteries included. This library includes all necessary code to validate RS256/RS384/RS512/ES256/ES384/ES512-signed JWTs. E.g. it contains a simple (and pluggable) **HTTP** helper to fetch the **JWKS** from the JWKS URI.
 - Opinionated towards the **best practices** as described by the IETF in [JSON Web Token Best Current Practices](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-jwt-bcp-02#section-3).
-- Make it **easy** for users to use this library in a **secure** way. For example, this library requires users to specify `issuer` and `audience`, as these should be checked for (see best practices linked to above).
+- Make it **easy** for users to use this library in a **secure** way. For example, this library requires users to specify `issuer` and `audience`, as these should be checked for (see best practices linked to above). Other standard claims, such as `exp` and `nbf`, are checked as well.
 
 Currently, signature algorithms **RS256** , **RS384** , **RS512** and **ES256** , **ES384** , **ES512** are supported.
 
@@ -175,6 +176,7 @@ Except the User Pool ID, parameters provided when creating the `CognitoJwtVerifi
 
 Supported parameters are:
 
+- `userPoolId` (mandatory): the Cognito User Pool ID. The issuer (`iss`) and `jwksUri` will be determined from this.
 - `tokenUse` (mandatory): verify that the JWT's `token_use` claim matches your expectation. Set to either `id` or `access`. Set to `null` to skip checking `token_use`.
 - `clientId` (mandatory): verify that the JWT's `aud` (id token) or `client_id` (access token) claim matches your expectation. Provide a string, or an array of strings to allow multiple client ids (i.e. one of these client ids must match the JWT). Set to `null` to skip checking client id (not recommended unless you know what you are doing).
 - `groups` (optional): verify that the JWT's `cognito:groups` claim matches your expectation. Provide a string, or an array of strings to allow multiple groups (i.e. one of these groups must match the JWT).
@@ -398,6 +400,7 @@ Except `issuer`, parameters provided when creating the `JwtVerifier` act as defa
 
 Supported parameters are:
 
+- `issuer` (mandatory): set this to the expected `iss` claim on the JWTs. Provide a single string, or set to `null` to skip checking issuer (not recommended unless you know what you are doing).
 - `jwksUri` (optional, can only be provided at verifier level): the URI where the JWKS can be downloaded from. To find this URI for your IDP, consult your IDP's OpenId configuration (e.g. by opening the OpenId configuration in your browser). Usually, it is `${issuer}/.well-known/jwks.json`, which is the default value that will be used if you don't explicitly provide `jwksUri`.
 - `audience` (mandatory): verify that the JWT's `aud` claim matches your expectation. Provide a string, or an array of strings to allow multiple client ids (i.e. one of these audiences must match the JWT). Set to `null` to skip checking audience (not recommended unless you know what you are doing). Note that a JWT's `aud` claim might be an array of audiences. The `JwtVerifier` will in that case make sure that at least one of these audiences matches with at least one of the audiences that were provided to the verifier.
 - `scope` (optional): verify that the JWT's `scope` claim matches your expectation (only of use for access tokens). Provide a string, or an array of strings to allow multiple scopes (i.e. one of these scopes must match the JWT). See also [Checking scope](#checking-scope).
@@ -443,6 +446,8 @@ const verifier = CognitoJwtVerifier.create(
   }
 );
 ```
+
+Alternatively, you can code a [custom JWT check](#custom-jwt-and-jwk-checks) to enforce that the JWT's header `alg` value matches the `alg` you want to enforce.
 
 ## Peeking inside unverified JWTs
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ try {
 
 See all verify parameters for JWTs from any IDP [here](#JwtVerifier-verify-parameters).
 
+### Non-standard IDPs
+
+For special cases you may want to use the library more raw:
+
+```typescript
+import { verifyJwt } from "aws-jwt-verify/jwt-verifier"; // there is also verifySync() which requires you to already have the JWK(S)
+import { SimpleJwksCache } from "aws-jwt-verify/jwk";
+
+const jwksCache = new SimpleJwksCache();
+
+try {
+  const payload = await verifyJwt(
+    "eyJraWQeyJhdF9oYXNoIjoidk...", // the JWT as string
+    "https://example.com/.well-known/jwks.json", // set this to the JWKS uri from your OpenID configuration
+    {
+      issuer: "<iss>", // set this to the expected iss claim on the JWT
+      audience: "<aud>", // set this to the expected aud claim on the JWT
+    },
+    jwksCache.getJwk.bind(jwksCache) // use JWKS cache (optional)
+  );
+  console.log("Token is valid. Payload:", payload);
+} catch {
+  console.log("Token not valid!");
+}
+```
+
 ## Philosophy of this library
 
 - Do one thing and do it well. Focus solely on **verifying** JWTs.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See all verify parameters for JWTs from any IDP [here](#JwtVerifier-verify-param
 For special cases you may want to use the library more raw:
 
 ```typescript
-import { verifyJwt } from "aws-jwt-verify/jwt-verifier"; // there is also verifySync() which requires you to already have the JWK(S)
+import { verifyJwt } from "aws-jwt-verify/jwt-verifier"; // there is also verifyJwtSync() for if you already have the JWK(S) ready
 import { SimpleJwksCache } from "aws-jwt-verify/jwk";
 
 const jwksCache = new SimpleJwksCache();

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ import { verifyJwt } from "aws-jwt-verify/jwt-verifier"; // there is also verify
 import { SimpleJwksCache } from "aws-jwt-verify/jwk";
 
 // E.g. use SimpleJwksCache to fetch and cache JSON Web Key Sets (JWKS)
+// SimpleJwksCache will deal with key rotations automatically
 const jwksCache = new SimpleJwksCache();
 
 try {
@@ -91,7 +92,7 @@ try {
 - Support both **Amazon Cognito** as well as any other **OIDC-compatible IDP** as first class citizen.
 - **0** runtime dependencies, batteries included. This library includes all necessary code to validate RS256/RS384/RS512/ES256/ES384/ES512-signed JWTs. E.g. it contains a simple (and pluggable) **HTTP** helper to fetch the **JWKS** from the JWKS URI.
 - Opinionated towards the **best practices** as described by the IETF in [JSON Web Token Best Current Practices](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-jwt-bcp-02#section-3).
-- Make it **easy** for users to use this library in a **secure** way. For example, this library requires users to specify `issuer` and `audience`, as these should be checked for (see best practices linked to above). Other standard claims, such as `exp` and `nbf`, are checked as well.
+- Make it **easy** for users to use this library in a **secure** way. For example, this library requires users to specify `issuer` and `audience`, as these should be checked for (see best practices linked to above). Standard claims, such as `exp` and `nbf`, are checked automatically.
 
 Currently, signature algorithms **RS256** , **RS384** , **RS512** and **ES256** , **ES384** , **ES512** are supported.
 

--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -382,7 +382,7 @@ export class CognitoJwtVerifier<
     let issuer: string | undefined;
     if (userPoolId !== undefined) {
       issuer = CognitoJwtVerifier.parseUserPoolId(userPoolId).issuer;
-    } else if (this.expectedIssuers.length > 1) {
+    } else if ((Array.from(this.issuersConfig)).length > 1) {
       throw new ParameterValidationError("userPoolId must be provided");
     }
     const issuerConfig = this.getIssuerConfig(issuer);

--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -382,7 +382,7 @@ export class CognitoJwtVerifier<
     let issuer: string | undefined;
     if (userPoolId !== undefined) {
       issuer = CognitoJwtVerifier.parseUserPoolId(userPoolId).issuer;
-    } else if ((Array.from(this.issuersConfig)).length > 1) {
+    } else if (Array.from(this.issuersConfig).length > 1) {
       throw new ParameterValidationError("userPoolId must be provided");
     }
     const issuerConfig = this.getIssuerConfig(issuer);

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -345,10 +345,22 @@ export class SimpleJwksCache implements JwksCache {
     this.jwksParser = props?.jwksParser ?? parseJwks;
   }
 
+  /**
+   * Add a JWKS to the cache explicitly. E.g. you may want to do this, if you have already downloaded the JWKS.
+   *
+   * @param jwksUri - The URI where your IDP exposes the JWKS, e.g. `https://example.com/my-idp/.well-known/jwks.json` (this is used as cache key)
+   * @param jwks - The JWKS
+   */
   public addJwks(jwksUri: string, jwks: Jwks): void {
     this.jwksCache.set(jwksUri, jwks);
   }
 
+  /**
+   * Fetch and cache the JWKS from the jwksUri
+   *
+   * @param jwksUri - The URI where your IDP exposes the JWKS, e.g. `https://example.com/my-idp/.well-known/jwks.json`
+   * @returns - The fetched jwks
+   */
   public async getJwks(jwksUri: string): Promise<Jwks> {
     const existingFetch = this.fetchingJwks.get(jwksUri);
     if (existingFetch) {
@@ -366,6 +378,13 @@ export class SimpleJwksCache implements JwksCache {
     return jwks;
   }
 
+  /**
+   * Get the JWKS from the cache (synchronously). Raises an error if the JWKS is not yet cached, or does not have the right JWK.
+   *
+   * @param jwksUri - The URI where your IDP exposes the JWKS, e.g. `https://example.com/my-idp/.well-known/jwks.json` (this is used as cache key)
+   * @param decomposedJwt - The decomposed JWT
+   * @returns - The previously cached JWKS
+   */
   public getCachedJwk(
     jwksUri: string,
     decomposedJwt: DecomposedJwt
@@ -392,6 +411,14 @@ export class SimpleJwksCache implements JwksCache {
     return jwk;
   }
 
+  /**
+   * Get the right JWK to verify the JWT with. This will fetch (and cache) the JWKS in case it's not yet been cached,
+   * or if the cached JWKS doesn't have the right JWK (to account for key rotations, based on `kid`).
+   *
+   * @param jwksUri
+   * @param decomposedJwt
+   * @returns  - The JWK
+   */
   public async getJwk(
     jwksUri: string,
     decomposedJwt: DecomposedJwt

--- a/src/jwt-verifier.ts
+++ b/src/jwt-verifier.ts
@@ -29,6 +29,7 @@ import {
 } from "./jwt.js";
 import {
   JwtInvalidClaimError,
+  JwtInvalidIssuerError,
   JwtInvalidSignatureAlgorithmError,
   JwtInvalidSignatureError,
   KidNotFoundInJwksError,
@@ -629,6 +630,14 @@ export abstract class JwtVerifierBase<
     verifyProperties: SpecificVerifyProperties;
   } {
     const decomposedJwt = decomposeUnverifiedJwt(jwt);
+    if (decomposedJwt.payload.iss != null) {
+      assertStringArrayContainsString(
+        "Issuer",
+        decomposedJwt.payload.iss,
+        this.expectedIssuers.filter((iss) => iss != null),
+        JwtInvalidIssuerError
+      );
+    }
     const issuerConfig = this.getIssuerConfig(decomposedJwt.payload.iss);
     return {
       decomposedJwt,

--- a/src/jwt-verifier.ts
+++ b/src/jwt-verifier.ts
@@ -29,7 +29,6 @@ import {
 } from "./jwt.js";
 import {
   JwtInvalidClaimError,
-  JwtInvalidIssuerError,
   JwtInvalidSignatureAlgorithmError,
   JwtInvalidSignatureError,
   KidNotFoundInJwksError,


### PR DESCRIPTION
*Issue #, if available:* #178

*Description of changes:* Allow creating a JwtVerifier for issuer `null` -- that is needed for non-standard IDPs that do not populate the `iss` claim (in our lib `issuer: null` means "do not check the iss claim")


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
