### PR TITLE
Compile regexp once and optimize CUP regex

### DIFF
--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -221,7 +221,7 @@ export class CognitoJwtVerifier<
   },
   MultiIssuer extends boolean,
 > extends JwtVerifierBase<SpecificVerifyProperties, IssuerConfig, MultiIssuer> {
-  private static userPoolIdRegex =
+  private static USER_POOL_ID_REGEX =
     /^(?<region>[a-z]{2}-(gov-)?[a-z]+-\d)_[a-zA-Z0-9]+$/;
   private constructor(
     props: CognitoJwtVerifierProperties | CognitoJwtVerifierMultiProperties[],
@@ -251,7 +251,7 @@ export class CognitoJwtVerifier<
     issuer: string;
     jwksUri: string;
   } {
-    const match = userPoolId.match(this.userPoolIdRegex);
+    const match = userPoolId.match(this.USER_POOL_ID_REGEX);
     if (!match) {
       throw new ParameterValidationError(
         `Invalid Cognito User Pool ID: ${userPoolId}`

--- a/src/cognito-verifier.ts
+++ b/src/cognito-verifier.ts
@@ -221,6 +221,8 @@ export class CognitoJwtVerifier<
   },
   MultiIssuer extends boolean,
 > extends JwtVerifierBase<SpecificVerifyProperties, IssuerConfig, MultiIssuer> {
+  private static userPoolIdRegex =
+    /^(?<region>[a-z]{2}-(gov-)?[a-z]+-\d)_[a-zA-Z0-9]+$/;
   private constructor(
     props: CognitoJwtVerifierProperties | CognitoJwtVerifierMultiProperties[],
     jwksCache?: JwksCache
@@ -249,9 +251,7 @@ export class CognitoJwtVerifier<
     issuer: string;
     jwksUri: string;
   } {
-    // Disable safe regexp check as userPoolId is provided by developer, i.e. is not user input
-    // eslint-disable-next-line security/detect-unsafe-regex
-    const match = userPoolId.match(/^(?<region>(\w+-)?\w+-\w+-\d)+_\w+$/);
+    const match = userPoolId.match(this.userPoolIdRegex);
     if (!match) {
       throw new ParameterValidationError(
         `Invalid Cognito User Pool ID: ${userPoolId}`

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -123,6 +123,9 @@ function assertJwtPayload(
   }
 }
 
+const JWT_REGEX =
+  /^[A-Za-z0-9_-]+={0,2}\.[A-Za-z0-9_-]+={0,2}\.[A-Za-z0-9_-]+={0,2}$/;
+
 /**
  * Sanity check, decompose and JSON parse a JWT string into its constituent, and yet unverified, parts:
  * - header object
@@ -145,11 +148,7 @@ export function decomposeUnverifiedJwt(jwt: unknown): DecomposedJwt {
   if (typeof jwt !== "string") {
     throw new JwtParseError("JWT is not a string");
   }
-  if (
-    !jwt.match(
-      /^[A-Za-z0-9_-]+={0,2}\.[A-Za-z0-9_-]+={0,2}\.[A-Za-z0-9_-]+={0,2}$/
-    )
-  ) {
+  if (!JWT_REGEX.test(jwt)) {
     throw new JwtParseError(
       "JWT string does not consist of exactly 3 parts (header, payload, signature)"
     );


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Tweaked regular expressions so that they are compiled only once, and the CUP regular expression is slightly sharper now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
