### PR TITLE
fix: Fetcher interface data type

### DIFF
--- a/src/https.ts
+++ b/src/https.ts
@@ -29,7 +29,7 @@ export interface Fetcher {
   fetch: (
     uri: string,
     requestOptions?: FetchRequestOptions,
-    data?: Buffer
+    data?: ArrayBuffer
   ) => Promise<ArrayBuffer>;
 }
 

--- a/tests/vite-app/cypress/e2e/fetcher.cy.ts
+++ b/tests/vite-app/cypress/e2e/fetcher.cy.ts
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+import { SimpleFetcher } from "aws-jwt-verify/https";
+
+describe("Fetcher", () => {
+  let tokenData;
+
+  beforeEach(() => {
+    cy.fixture("example-token-data.json").then((data) => {
+      tokenData = data;
+    });
+  });
+
+  it("Simple JSON fetcher works", () => {
+    cy.visit("/");
+
+    cy.fixture("example-JWKS.json").then((jwksData) => {
+      const fetcher = new SimpleFetcher();
+
+      fetcher.fetch(tokenData.JWKSURI).then((jwks) => {
+        expect(jwks).to.deep.equal(jwksData);
+      });
+    });
+  });
+});

--- a/tests/vite-app/tsconfig.json
+++ b/tests/vite-app/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "include": ["src"]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed `tsc` compile error when tsconfig.json has `"skipLibCheck": false` for a web application
  `Type 'Buffer<ArrayBufferLike> | undefined' is not assignable to type 'ArrayBuffer | undefined'.`
- added a Cypress `SimpleFetcher` test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
