### PR TITLE
docs: update to at least Node.js v18

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ Please provide a clear and concise description of what the bug is.
 **Versions**
 Which version of `aws-jwt-verify` are you using?
 Are you using the library in Node.js or in the Web browser?
-If Node.js, which version of Node.js are you using? (Should be at least 16)
+If Node.js, which version of Node.js are you using? (Should be at least 18)
 If Web browser, which web browser and which version of it are you using?
 If using TypeScript, which version of TypeScript are you using? (Should be at least 4)
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -12,6 +12,6 @@ How can we help you?
 **Versions**
 Which version of `aws-jwt-verify` are you using?
 Are you using the library in Node.js or in the Web browser?
-If Node.js, which version of Node.js are you using? (Should be at least 16)
+If Node.js, which version of Node.js are you using? (Should be at least 18)
 If Web browser, which web browser and which version of it are you using?
 If using TypeScript, which version of TypeScript are you using? (Should be at least 4)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `npm install aws-jwt-verify`
 
-This library can be used with Node.js 16 or higher. If used with TypeScript, TypeScript 4 or higher is required.
+This library can be used with Node.js 18 or higher. If used with TypeScript, TypeScript 4 or higher is required.
 
 This library can also be used in Web browsers.
 
@@ -88,7 +88,7 @@ try {
 ## Philosophy of this library
 
 - Do one thing and do it well. Focus solely on **verifying** JWTs.
-- Pure **TypeScript** library that can be used in **Node.js** v16 and above (both CommonJS and ESM supported), as well in the modern evergreen Web browser.
+- Pure **TypeScript** library that can be used in **Node.js** v18 and above (both CommonJS and ESM supported), as well in the modern evergreen Web browser.
 - Support both **Amazon Cognito** as well as any other **OIDC-compatible IDP** as first class citizen.
 - **0** runtime dependencies, batteries included. This library includes all necessary code to verify JWTs. E.g. it contains a simple (and pluggable) **HTTP** helper to fetch the **JWKS** from the JWKS URI.
 - Opinionated towards the **best practices** as described by the IETF in [JSON Web Token Best Current Practices](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-jwt-bcp-02#section-3).

--- a/package.json
+++ b/package.json
@@ -130,6 +130,6 @@
     "url": "https://github.com/awslabs/aws-jwt-verify.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

#196 

*Description of changes:*

- updated docs to reference Node.js v18 as minimum
- updated `engines` to `"node": ">=18.0.0"` which only emits a WARN installing on Node.js v16 because `engineStrict` is default `false`
- left `tsconfig.json` as `"extends": "@tsconfig/node16/tsconfig.json",` and  `devDependencies` as `"@types/node": "^16.10.2",`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
