### PR TITLE
fix: CognitoJwtVerifier.hydrate()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-jwt-verify",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-jwt-verify",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-jwt-verify",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Verify JSON Web Tokens (JWT) from Amazon Cognito and other IDPs",
   "license": "Apache-2.0",
   "author": {

--- a/src/jwt-verifier.ts
+++ b/src/jwt-verifier.ts
@@ -530,7 +530,12 @@ export abstract class JwtVerifierBase<
     const jwksFetches = Array.from(this.issuersConfig.values()).map(
       ({ jwksUri }) => this.jwksCache.getJwks(jwksUri)
     );
-    await Promise.all(jwksFetches);
+    const results = await Promise.allSettled(jwksFetches);
+    // Ensure at least one fetch succeeded; if all failed, throw the first error
+    const allFailed = results.every((r) => r.status === "rejected");
+    if (allFailed) {
+      throw (results[0] as PromiseRejectedResult).reason;
+    }
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:* #279

*Description of changes:*

* use Promise.allSettled for CognitoJwtVerifier.hydrate()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
